### PR TITLE
Replace print with debugPrint

### DIFF
--- a/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
@@ -23,7 +23,7 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
       await bellPlayer.setAsset('assets/sons/quiz/bell.mp3');
       bellPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son bell : \$e");
+      debugPrint("Erreur de lecture du son bell : \$e");
     }
 
     await showDialog(
@@ -239,7 +239,7 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
       await wooshPlayer.setAsset('assets/sons/quiz/woosh.mp3');
       wooshPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son woosh : \$e");
+      debugPrint("Erreur de lecture du son woosh : \$e");
     }
 
     await showDialog(
@@ -567,7 +567,7 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
       await _player.setLoopMode(LoopMode.all);
       _player.play();
     } catch (e) {
-      print("Erreur lors de la lecture du son : $e");
+      debugPrint("Erreur lors de la lecture du son : $e");
     }
   }
 
@@ -576,7 +576,7 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
       await _gunPlayer.setAsset('assets/sons/quiz/gun2.mp3');
       _gunPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son de tir : $e");
+      debugPrint("Erreur de lecture du son de tir : $e");
     }
   }
 

--- a/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
@@ -23,7 +23,7 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
       await bellPlayer.setAsset('assets/sons/quiz/bell.mp3');
       bellPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son bell : \$e");
+      debugPrint("Erreur de lecture du son bell : \$e");
     }
 
     await showDialog(
@@ -239,7 +239,7 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
       await wooshPlayer.setAsset('assets/sons/quiz/woosh.mp3');
       wooshPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son woosh : \$e");
+      debugPrint("Erreur de lecture du son woosh : \$e");
     }
 
     await showDialog(
@@ -567,7 +567,7 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
       await _player.setLoopMode(LoopMode.all);
       _player.play();
     } catch (e) {
-      print("Erreur lors de la lecture du son : $e");
+      debugPrint("Erreur lors de la lecture du son : $e");
     }
   }
 
@@ -576,7 +576,7 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
       await _gunPlayer.setAsset('assets/sons/quiz/gun2.mp3');
       _gunPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son de tir : $e");
+      debugPrint("Erreur de lecture du son de tir : $e");
     }
   }
 

--- a/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
@@ -22,7 +22,7 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
       await bellPlayer.setAsset('assets/sons/quiz/bell.mp3');
       bellPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son bell : \$e");
+      debugPrint("Erreur de lecture du son bell : \$e");
     }
 
     await showDialog(
@@ -238,7 +238,7 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
       await wooshPlayer.setAsset('assets/sons/quiz/woosh.mp3');
       wooshPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son woosh : \$e");
+      debugPrint("Erreur de lecture du son woosh : \$e");
     }
 
     await showDialog(
@@ -566,7 +566,7 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
       await _player.setLoopMode(LoopMode.all);
       _player.play();
     } catch (e) {
-      print("Erreur lors de la lecture du son : $e");
+      debugPrint("Erreur lors de la lecture du son : $e");
     }
   }
 
@@ -575,7 +575,7 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
       await _gunPlayer.setAsset('assets/sons/quiz/gun2.mp3');
       _gunPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son de tir : $e");
+      debugPrint("Erreur de lecture du son de tir : $e");
     }
   }
 

--- a/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
@@ -22,7 +22,7 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
       bellPlayer.play();
       await bellPlayer.dispose();
     } catch (e) {
-      print("Erreur de lecture du son bell : \$e");
+      debugPrint("Erreur de lecture du son bell : \$e");
     }
 
     await showDialog(
@@ -237,7 +237,7 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
       await wooshPlayer.setAsset('assets/sons/quiz/woosh.mp3');
       wooshPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son woosh : \$e");
+      debugPrint("Erreur de lecture du son woosh : \$e");
     }
 
     await showDialog(
@@ -566,7 +566,7 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
       await _player.setLoopMode(LoopMode.all);
       _player.play();
     } catch (e) {
-      print("Erreur lors de la lecture du son : $e");
+      debugPrint("Erreur lors de la lecture du son : $e");
     }
   }
 
@@ -575,7 +575,7 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
       await _gunPlayer.setAsset('assets/sons/quiz/gun2.mp3');
       _gunPlayer.play();
     } catch (e) {
-      print("Erreur de lecture du son de tir : $e");
+      debugPrint("Erreur de lecture du son de tir : $e");
     }
   }
 

--- a/lib/screens/duel_screens/duel_game_screen.dart
+++ b/lib/screens/duel_screens/duel_game_screen.dart
@@ -60,7 +60,7 @@ void initState() {
   Future<void> _loadDuel() async {
     final docRef = FirebaseFirestore.instance.collection('duels').doc(widget.duelId);
     final doc = await docRef.get();
-    print("📄 Document récupéré pour le duel ${widget.duelId} : ${doc.exists}");
+    debugPrint("📄 Document récupéré pour le duel ${widget.duelId} : ${doc.exists}");
 
     if (!doc.exists) {
       setState(() {
@@ -71,7 +71,7 @@ void initState() {
     // Removed previous hasAlreadyPlayed assignment. It will be computed after mapping duelQuestions.
 
     final data = doc.data();
-    print("📊 Données du duel : $data");
+    debugPrint("📊 Données du duel : $data");
     if (data == null) {
       setState(() {
         isLoading = false;
@@ -101,7 +101,7 @@ void initState() {
             'answer': correctAnswer,
           };
         } catch (e) {
-          print('❌ Erreur lors du mapping d’une question existante Firestore : $e');
+          debugPrint('❌ Erreur lors du mapping d’une question existante Firestore : $e');
           return {
             'text': 'Question invalide',
             'options': ['Erreur'],
@@ -111,8 +111,8 @@ void initState() {
       }
     }).toList();
 
-    print("✅ Questions générées : $duelQuestions");
-    print("🛠 Questions locales mappées : $duelQuestions");
+    debugPrint("✅ Questions générées : $duelQuestions");
+    debugPrint("🛠 Questions locales mappées : $duelQuestions");
 
     await docRef.update({'questions': duelQuestions});
 
@@ -129,7 +129,7 @@ void initState() {
       });
     }
 
-    print("✅ Chargement terminé. ${duelQuestions.length} question(s) prêtes.");
+    debugPrint("✅ Chargement terminé. ${duelQuestions.length} question(s) prêtes.");
     final userField = currentUser!.uid == doc.data()?['from'] ? 'player1' : 'player2';
     final userData = doc.data()?[userField] ?? {};
     final answers = (userData['answers'] as Map?) ?? {};

--- a/lib/screens/duel_screens/duel_user_list_screen.dart
+++ b/lib/screens/duel_screens/duel_user_list_screen.dart
@@ -60,7 +60,7 @@ class _DuelUserListScreenState extends State<DuelUserListScreen> {
     final myId = currentUser.uid;
     final mySnapshot = await FirebaseFirestore.instance.collection('users').doc(myId).get();
     final myPseudo = mySnapshot.data()?['pseudo'] ?? 'Joueur';
-    print('sendDuelRequest: myId=$myId, opponentId=$opponentId, opponentPseudo=$opponentPseudo');
+    debugPrint('sendDuelRequest: myId=$myId, opponentId=$opponentId, opponentPseudo=$opponentPseudo');
 
     List<Map<String, dynamic>> allQuestions = [];
 
@@ -93,7 +93,7 @@ class _DuelUserListScreenState extends State<DuelUserListScreen> {
       }
     }
 
-    print('sendDuelRequest: Total questions generated: ${allQuestions.length}');
+    debugPrint('sendDuelRequest: Total questions generated: ${allQuestions.length}');
 
     // Préparer les données du duel, en ajoutant le champ 'domainesEnvoyeur'
     final duelData = {
@@ -119,7 +119,7 @@ class _DuelUserListScreenState extends State<DuelUserListScreen> {
     };
 
     final duelRef = await FirebaseFirestore.instance.collection('duels').add(duelData);
-    print('sendDuelRequest: Duel request sent successfully. Duel ID: ${duelRef.id}');
+    debugPrint('sendDuelRequest: Duel request sent successfully. Duel ID: ${duelRef.id}');
 
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'presence_service.dart';
 
 class AuthService {
@@ -28,7 +29,7 @@ class AuthService {
       }
       return user;
     } catch (e) {
-      print("❌ Erreur d'authentification Google : $e");
+      debugPrint("❌ Erreur d'authentification Google : $e");
       return null;
     }
   }
@@ -56,7 +57,7 @@ class AuthService {
       }
       return user;
     } catch (e) {
-      print("❌ Erreur d'authentification Apple : $e");
+      debugPrint("❌ Erreur d'authentification Apple : $e");
       return null;
     }
   }
@@ -74,7 +75,7 @@ class AuthService {
       }
       return user;
     } catch (e) {
-      print("❌ Erreur d'inscription : $e");
+      debugPrint("❌ Erreur d'inscription : $e");
       return null;
     }
   }
@@ -92,7 +93,7 @@ class AuthService {
       }
       return user;
     } catch (e) {
-      print("❌ Erreur d'authentification Email : $e");
+      debugPrint("❌ Erreur d'authentification Email : $e");
       return null;
     }
   }
@@ -105,9 +106,9 @@ class AuthService {
       if (await _googleSignIn.isSignedIn()) {
         await _googleSignIn.signOut();
       }
-      print("✅ Déconnexion réussie");
+      debugPrint("✅ Déconnexion réussie");
     } catch (e) {
-      print("❌ Erreur lors de la déconnexion : $e");
+      debugPrint("❌ Erreur lors de la déconnexion : $e");
     }
   }
 }

--- a/lib/services/profile_service.dart
+++ b/lib/services/profile_service.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 
 class ProfileService {
   final FirebaseFirestore _db = FirebaseFirestore.instance;
@@ -7,12 +8,12 @@ class ProfileService {
   // 🔹 Vérifie si l'utilisateur a un profil complet
   Future<bool> hasProfile(String uid) async {
     try {
-      print("🔎 [Firestore] Vérification du profil pour UID: $uid");
+      debugPrint("🔎 [Firestore] Vérification du profil pour UID: $uid");
 
       var doc = await _db.collection('users').doc(uid).get();
 
       if (!doc.exists) {
-        print("❌ [Firestore] Aucun profil trouvé !");
+        debugPrint("❌ [Firestore] Aucun profil trouvé !");
         return false;
       }
 
@@ -21,14 +22,14 @@ class ProfileService {
       final isValid = pseudo.toString().trim().isNotEmpty;
 
       if (isValid) {
-        print("✅ [Firestore] Profil complet trouvé !");
+        debugPrint("✅ [Firestore] Profil complet trouvé !");
       } else {
-        print("❌ [Firestore] Profil incomplet (pseudo manquant)");
+        debugPrint("❌ [Firestore] Profil incomplet (pseudo manquant)");
       }
 
       return isValid;
     } catch (e) {
-      print("⚠️ [Erreur Firestore - hasProfile] $e");
+      debugPrint("⚠️ [Erreur Firestore - hasProfile] $e");
       return false;
     }
   }
@@ -36,7 +37,7 @@ class ProfileService {
   // 🔹 Crée un profil utilisateur
   Future<void> createProfile(String uid, String pseudo, String avatar, String bio) async {
     try {
-      print("📝 [Firestore] Création du profil pour UID: $uid");
+      debugPrint("📝 [Firestore] Création du profil pour UID: $uid");
 
       await _db.collection('users').doc(uid).set({
         "uid": uid,
@@ -52,28 +53,28 @@ class ProfileService {
         "glands": 0,
       });
 
-      print("✅ [Firestore] Profil créé avec succès !");
+      debugPrint("✅ [Firestore] Profil créé avec succès !");
     } catch (e) {
-      print("⚠️ [Erreur Firestore - createProfile] $e");
+      debugPrint("⚠️ [Erreur Firestore - createProfile] $e");
     }
   }
 
   // 🔹 Récupère les infos du profil utilisateur
   Future<Map<String, dynamic>?> getProfile(String uid) async {
     try {
-      print("📡 [Firestore] Récupération du profil pour UID: $uid");
+      debugPrint("📡 [Firestore] Récupération du profil pour UID: $uid");
 
       var doc = await _db.collection('users').doc(uid).get();
 
       if (doc.exists) {
-        print("✅ [Firestore] Profil récupéré : ${doc.data()}");
+        debugPrint("✅ [Firestore] Profil récupéré : ${doc.data()}");
         return doc.data();
       } else {
-        print("❌ [Firestore] Aucun profil trouvé !");
+        debugPrint("❌ [Firestore] Aucun profil trouvé !");
         return null;
       }
     } catch (e) {
-      print("⚠️ [Erreur Firestore - getProfile] $e");
+      debugPrint("⚠️ [Erreur Firestore - getProfile] $e");
       return null;
     }
   }
@@ -89,7 +90,7 @@ class ProfileService {
       // S’il existe au moins un document dont l’ID est différent de excludeUid, le pseudo est pris
       return query.docs.any((doc) => doc.id != excludeUid);
     } catch (e) {
-      print("⚠️ [Firestore - isPseudoTaken] $e");
+      debugPrint("⚠️ [Firestore - isPseudoTaken] $e");
       // En cas d’erreur, on considère le pseudo comme déjà pris pour éviter les conflits
       return true;
     }


### PR DESCRIPTION
## Summary
- éviter `print` en production
- utiliser `debugPrint` pour tous les logs
- ajouter les imports requis

## Testing
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6848b5e1be84832d889d81b15c9d096f