### PR TITLE
Ajout de l'option Revanche

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Nouveauté
+
+* Possibilité de demander une **Revanche** depuis l'écran de résultat d'un duel.


### PR DESCRIPTION
## Notes
- ajout d'un bouton **Revanche** sur l'écran de résultat d'un duel
- création d'un duel de revanche avec sélection de domaines puis ouverture immédiate de la nouvelle partie
- mise à jour du README pour décrire cette fonctionnalité

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6848b96277f0832da6d3129edf93e0b2