### PR TITLE
Ajout de la permission INTERNET

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:usesCleartextTraffic="true"
         android:label="corsicaquiz"


### PR DESCRIPTION
## Notes
- Ajout de la permission `INTERNET` dans le fichier AndroidManifest.
- Impossible de lancer la compilation : la commande `flutter` n'est pas disponible.


------
https://chatgpt.com/codex/tasks/task_e_6848c4f4924c832d8ef2e3428f071548