### PR TITLE
Add SnackBar on Google sign-in failure

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -7,15 +7,25 @@ import '../screens/home_screen.dart';
 import '../screens/profile_screen.dart';
 
 class LoginScreen extends StatefulWidget {
+  final AuthService? authService;
+
+  const LoginScreen({Key? key, this.authService}) : super(key: key);
+
   @override
   _LoginScreenState createState() => _LoginScreenState();
 }
 
 class _LoginScreenState extends State<LoginScreen> {
-  final AuthService _authService = AuthService();
+  late final AuthService _authService;
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   bool _isLoading = false; // Indicateur de chargement
+
+  @override
+  void initState() {
+    super.initState();
+    _authService = widget.authService ?? AuthService();
+  }
 
   void _handleAuth() async {
     setState(() => _isLoading = true);
@@ -270,6 +280,10 @@ class _LoginScreenState extends State<LoginScreen> {
                               ? HomeScreen(user: user)
                               : ProfileScreen(user: user),
                         ),
+                      );
+                    } else {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Échec de la connexion')),
                       );
                     }
                   },

--- a/test/login_screen_test.dart
+++ b/test/login_screen_test.dart
@@ -1,13 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:corsicaquiz/screens/login_screen.dart';
+import 'package:corsicaquiz/services/auth_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockAuthService extends Mock implements AuthService {}
 
 void main() {
+
   testWidgets('LoginScreen affiche le bouton Connexion', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: LoginScreen()));
 
     expect(find.text('Connexion'), findsOneWidget);
     expect(find.byType(TextField), findsNWidgets(2));
     expect(find.text("Créer un compte"), findsOneWidget);
+  });
+
+  testWidgets('Affiche un SnackBar si la connexion Google échoue', (tester) async {
+    final mockAuth = MockAuthService();
+    when(() => mockAuth.signInWithGoogle()).thenAnswer((_) async => null);
+
+    await tester.pumpWidget(MaterialApp(home: LoginScreen(authService: mockAuth)));
+
+    await tester.tap(find.text('Se connecter avec Google'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.text('Échec de la connexion'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- injecter `AuthService` dans `LoginScreen`
- signaler l'échec de la connexion Google via `SnackBar`
- tester l'affichage du message en cas de connexion Google ratée

## Testing
- `flutter test` *(échoue : commande indisponible)*

------
https://chatgpt.com/codex/tasks/task_e_6848c4fb6318832daed5035954c83449