### PR TITLE
Check profile creation on Google sign in

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -3,7 +3,9 @@ import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'dart:io';
 import 'package:flutter/foundation.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'presence_service.dart';
+import 'profile_service.dart';
 
 class AuthService {
   final FirebaseAuth _auth;
@@ -33,6 +35,18 @@ class AuthService {
       UserCredential userCredential = await _auth.signInWithCredential(credential);
       final user = userCredential.user;
       if (user != null) {
+        final doc = await FirebaseFirestore.instance
+            .collection('users')
+            .doc(user.uid)
+            .get();
+        if (!doc.exists) {
+          await ProfileService().createProfile(
+            user.uid,
+            user.displayName ?? '',
+            user.photoURL ?? '',
+            '',
+          );
+        }
         _presence.init(user.uid);
       }
       return user;


### PR DESCRIPTION
## Summary
- ensure a Firestore profile exists after Google sign-in

## Testing
- `flutter test test/auth_service_test.dart -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c4fcc468832dace9cb3666ff4a01