### PR TITLE
Ajout bouton de sélection aléatoire

### DIFF
--- a/lib/screens/duel_screens/opponent_domain_selection_screen.dart
+++ b/lib/screens/duel_screens/opponent_domain_selection_screen.dart
@@ -159,6 +159,28 @@ class _OpponentDomainSelectionScreenState extends State<OpponentDomainSelectionS
                 ),
               ),
               Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                child: ElevatedButton.icon(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.orangeAccent,
+                    foregroundColor: Colors.white,
+                    elevation: 4,
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  ),
+                  icon: const Icon(Icons.shuffle),
+                  label: const Text('Sélection aléatoire'),
+                  onPressed: () {
+                    final random = Random();
+                    final shuffled = List<String>.from(availableDomains)..shuffle(random);
+                    setState(() {
+                      for (int i = 0; i < selectedDomains.length; i++) {
+                        selectedDomains[i] = shuffled[i % shuffled.length];
+                      }
+                    });
+                  },
+                ),
+              ),
+              Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: FloatingActionButton.extended(
                   onPressed: selectedDomains.every((d) => d != null)


### PR DESCRIPTION
## Summary
- ajout d'un bouton **Sélection aléatoire** dans `OpponentDomainSelectionScreen`
- mélange des domaines disponibles grâce à `Random()` et remplissage de `selectedDomains`
- vérification que le bouton "Valider les domaines" reste actif uniquement quand six domaines sont choisis

## Testing
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68494e80bb24832dabd6ebe92166d484