### PR TITLE
Amélioration gestion favoris dans DuelUserList

### DIFF
--- a/lib/screens/duel_screens/duel_user_list_screen.dart
+++ b/lib/screens/duel_screens/duel_user_list_screen.dart
@@ -159,10 +159,21 @@ class _DuelUserListScreenState extends State<DuelUserListScreen> {
   Future<void> _toggleFavorite(String uid) async {
     final currentUser = FirebaseAuth.instance.currentUser;
     if (currentUser == null) return;
-    if (_favorites.contains(uid)) {
-      await _favoriteService.removeFavorite(currentUser.uid, uid);
-    } else {
-      await _favoriteService.addFavorite(currentUser.uid, uid);
+    try {
+      if (_favorites.contains(uid)) {
+        await _favoriteService.removeFavorite(currentUser.uid, uid);
+        setState(() => _favorites.remove(uid));
+      } else {
+        await _favoriteService.addFavorite(currentUser.uid, uid);
+        setState(() => _favorites.add(uid));
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Erreur lors de la mise à jour des favoris.'),
+          backgroundColor: Colors.red,
+        ),
+      );
     }
   }
 


### PR DESCRIPTION
## Notes
- `flutter test` n'a pas pu être exécuté car la commande `flutter` est indisponible dans l'environnement.

## Summary
- mise à jour immédiate de la liste `_favorites` après l'ajout ou le retrait
- gestion d'erreur lors de la mise à jour des favoris


------
https://chatgpt.com/codex/tasks/task_e_68494e75c390832dbc62e314b3eedc75