### PR TITLE
Ajout du quiz géographie

### DIFF
--- a/assets/data/questions_geographie.json
+++ b/assets/data/questions_geographie.json
@@ -1,0 +1,14 @@
+[
+  {"ville": "Ajaccio", "latitude": 41.919229, "longitude": 8.738635},
+  {"ville": "Bastia", "latitude": 42.697672, "longitude": 9.450962},
+  {"ville": "Calvi", "latitude": 42.566376, "longitude": 8.756933},
+  {"ville": "Corte", "latitude": 42.306397, "longitude": 9.150068},
+  {"ville": "Porto-Vecchio", "latitude": 41.591419, "longitude": 9.279619},
+  {"ville": "Bonifacio", "latitude": 41.387067, "longitude": 9.159307},
+  {"ville": "Sartène", "latitude": 41.622886, "longitude": 8.974305},
+  {"ville": "Île-Rousse", "latitude": 42.634925, "longitude": 8.937267},
+  {"ville": "Propriano", "latitude": 41.676137, "longitude": 8.907394},
+  {"ville": "Aléria", "latitude": 42.101586, "longitude": 9.513199},
+  {"ville": "Saint-Florent", "latitude": 42.683155, "longitude": 9.299641},
+  {"ville": "Ghisonaccia", "latitude": 42.014526, "longitude": 9.406066}
+]

--- a/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
@@ -1,0 +1,175 @@
+import 'dart:convert';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:lottie/lottie.dart';
+import 'classic_quiz_menu_screen.dart';
+
+class ClassicGeographieQuizScreen extends StatefulWidget {
+  const ClassicGeographieQuizScreen({super.key});
+
+  @override
+  State<ClassicGeographieQuizScreen> createState() => _ClassicGeographieQuizScreenState();
+}
+
+class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScreen> {
+  final MapController _mapController = MapController();
+  List<dynamic> _cities = [];
+  int _current = 0;
+  int _score = 0;
+  LatLng? _selected;
+  bool _answered = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadCities();
+  }
+
+  Future<void> _loadCities() async {
+    final data = await rootBundle.loadString('assets/data/questions_geographie.json');
+    setState(() {
+      _cities = json.decode(data);
+    });
+  }
+
+  Future<void> _updateGlandsInDatabase() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user != null) {
+      final ref = FirebaseFirestore.instance.collection('users').doc(user.uid);
+      await FirebaseFirestore.instance.runTransaction((tx) async {
+        final snap = await tx.get(ref);
+        final current = snap['glands'] ?? 0;
+        tx.update(ref, {'glands': current + _score});
+      });
+    }
+  }
+
+  void _onTap(TapPosition pos, LatLng latlng) {
+    if (_answered || _cities.isEmpty) return;
+    final city = _cities[_current];
+    final cityPoint = LatLng(city['latitude'], city['longitude']);
+    final distance = Distance().as(LengthUnit.Kilometer, latlng, cityPoint);
+    setState(() {
+      _selected = latlng;
+      _answered = true;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('Distance : ${distance.toStringAsFixed(1)} km'),
+        duration: const Duration(seconds: 2),
+      ),
+    );
+    if (distance < 10) _score++;
+    Future.delayed(const Duration(seconds: 2), () {
+      if (_current < _cities.length - 1) {
+        setState(() {
+          _current++;
+          _selected = null;
+          _answered = false;
+        });
+      } else {
+        _finishQuiz();
+      }
+    });
+  }
+
+  Future<void> _finishQuiz() async {
+    await _updateGlandsInDatabase();
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => Dialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+        backgroundColor: Colors.white,
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Lottie.asset('assets/lottie/cloudbird.json', height: 120),
+              const SizedBox(height: 10),
+              const Text('Quiz terminé !', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 10),
+              Text('Score : $_score / 12', textAlign: TextAlign.center),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(builder: (c) => ClassicQuizMenuScreen()),
+                  );
+                },
+                child: const Text('Retour au menu'),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_cities.isEmpty) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    final city = _cities[_current];
+    final realPoint = LatLng(city['latitude'], city['longitude']);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Géographie'),
+      ),
+      body: Stack(
+        children: [
+          FlutterMap(
+            mapController: _mapController,
+            options: MapOptions(
+              center: const LatLng(42.039604, 9.012893),
+              zoom: 7.5,
+              onTap: _onTap,
+            ),
+            children: [
+              TileLayer(
+                urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                userAgentPackageName: 'com.example.app',
+              ),
+              if (_selected != null)
+                MarkerLayer(markers: [
+                  Marker(point: _selected!, builder: (ctx) => const Icon(Icons.location_on, color: Colors.red, size: 40)),
+                ]),
+              if (_answered)
+                MarkerLayer(markers: [
+                  Marker(point: realPoint, builder: (ctx) => const Icon(Icons.flag, color: Colors.blue, size: 40)),
+                ]),
+            ],
+          ),
+          Positioned(
+            bottom: 20,
+            left: 20,
+            right: 20,
+            child: Column(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.8),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text('Où se situe ${city['ville']} ?'),
+                ),
+                const SizedBox(height: 8),
+                Text('Score : $_score / 12', style: const TextStyle(color: Colors.white)),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/screens/classic_quiz/classic_quiz_menu_screen.dart
+++ b/lib/screens/classic_quiz/classic_quiz_menu_screen.dart
@@ -8,6 +8,7 @@ import '/screens/classic_quiz/classic_histoire_quiz_screen.dart';
 import '/screens/classic_quiz/classic_culture_quiz_screen.dart';
 import '/screens/classic_quiz/classic_faune_quiz_screen.dart';
 import '/screens/classic_quiz/classic_personnalites_quiz_screen.dart';
+import '/screens/classic_quiz/classic_geographie_quiz_screen.dart';
 
 class _AnimatedFloatingButton extends StatefulWidget {
   final String text;
@@ -180,7 +181,12 @@ class ClassicQuizMenuScreen extends StatelessWidget {
                 ),
                 _AnimatedFloatingButton(
                   backgroundImage: 'assets/images/boiscartoon.png',
-                  onTap: () => _startQuiz(context, "Géographie"),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (context) => ClassicGeographieQuizScreen()),
+                    );
+                  },
                   text: "Géographie",
                 ),
                 _AnimatedFloatingButton(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,8 @@ dependencies:
   upgrader: ^11.3.1
   firebase_messaging: ^14.7.4
   flutter_local_notifications: ^16.1.0
+  flutter_map: ^6.0.0
+  latlong2: ^0.9.0
 
 dev_dependencies:
   flutter_test:
@@ -93,6 +95,7 @@ flutter:
    - assets/images/napoleon.png
    - assets/icons/
    - assets/data/
+   - assets/data/questions_geographie.json
    - assets/images/avatars/
    - assets/lottie/
    - assets/sons/quiz/


### PR DESCRIPTION
## Summary
- ajoute les dépendances `flutter_map` et `latlong2`
- déclare l'asset `questions_geographie.json`
- crée les données des villes corses
- crée l'écran `ClassicGeographieQuizScreen` avec une carte interactive
- ajoute l'entrée Géographie dans `ClassicQuizMenuScreen`

## Testing
- `flutter analyze` *(échoue : command not found)*
- `flutter test` *(échoue : command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684954ad1cac832db542e13ad0b97094