### PR TITLE
Ajout de l'écran des favoris

### DIFF
--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -1,0 +1,99 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import '../services/favorite_service.dart';
+
+class FavoritesScreen extends StatefulWidget {
+  const FavoritesScreen({Key? key}) : super(key: key);
+
+  @override
+  State<FavoritesScreen> createState() => _FavoritesScreenState();
+}
+
+class _FavoritesScreenState extends State<FavoritesScreen> {
+  final FavoriteService _favoriteService = FavoriteService();
+  StreamSubscription<List<String>>? _favSub;
+  List<Map<String, dynamic>> _favoriteUsers = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _listenFavorites();
+  }
+
+  void _listenFavorites() {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+    _favSub = _favoriteService.favoritesStream(uid).listen((uids) {
+      _fetchUsers(uids);
+    });
+  }
+
+  Future<void> _fetchUsers(List<String> uids) async {
+    if (uids.isEmpty) {
+      setState(() {
+        _favoriteUsers = [];
+        _loading = false;
+      });
+      return;
+    }
+
+    final futures = uids.map((id) =>
+        FirebaseFirestore.instance.collection('users').doc(id).get());
+    final docs = await Future.wait(futures);
+    if (!mounted) return;
+    setState(() {
+      _favoriteUsers = docs.map((doc) {
+        final data = doc.data() as Map<String, dynamic>? ?? {};
+        return {
+          'uid': doc.id,
+          'pseudo': data['pseudo'] ?? 'Sans pseudo',
+          'avatar': data['avatar'] ?? 'avatar_default.png',
+        };
+      }).toList();
+      _loading = false;
+    });
+  }
+
+  Future<void> _removeFavorite(String uid) async {
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser == null) return;
+    await _favoriteService.removeFavorite(currentUser.uid, uid);
+  }
+
+  @override
+  void dispose() {
+    _favSub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mes favoris')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _favoriteUsers.isEmpty
+              ? const Center(child: Text('Aucun favori.'))
+              : ListView.builder(
+                  itemCount: _favoriteUsers.length,
+                  itemBuilder: (context, index) {
+                    final user = _favoriteUsers[index];
+                    return ListTile(
+                      leading: CircleAvatar(
+                        backgroundImage: AssetImage(
+                          'assets/images/avatars/${user['avatar']}',
+                        ),
+                      ),
+                      title: Text(user['pseudo']),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.delete_outline),
+                        onPressed: () => _removeFavorite(user['uid']),
+                      ),
+                    );
+                  },
+                ),
+    );
+  }
+}


### PR DESCRIPTION
## Notes
- Impossible d'exécuter `flutter analyze` et `flutter test` car l'outil `flutter` n'est pas disponible dans l'environnement.

## Summary
- création de `favorites_screen.dart` pour afficher les utilisateurs favoris
- écoute du flux `favoritesStream` pour charger les données
- possibilité de retirer un favori depuis la liste


------
https://chatgpt.com/codex/tasks/task_e_6849c13feab4832dbd3c2cc70aa36bae