### PR TITLE
Supprimer AppBar et envelopper de SafeArea

### DIFF
--- a/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
@@ -122,7 +122,9 @@ class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScree
   @override
   Widget build(BuildContext context) {
     if (_cities.isEmpty) {
-      return Scaffold(body: Center(child: CircularProgressIndicator()));
+      return Scaffold(
+        body: SafeArea(child: Center(child: CircularProgressIndicator())),
+      );
     }
 
     final city = _cities[_current];
@@ -130,8 +132,8 @@ class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScree
     final realPoint = latlong2.LatLng(city['latitude'], city['longitude']);
 
     return Scaffold(
-      appBar: AppBar(title: Text('Géographie')),
-      body: Stack(
+      body: SafeArea(
+        child: Stack(
         children: [
           flutter_map.FlutterMap(
             mapController: _mapController,


### PR DESCRIPTION
## Summary
- enlever la barre d'app dans `classic_geographie_quiz_screen`
- protéger l'écran avec `SafeArea`

## Testing
- `dart test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6849c149b3ec832d9a98df3724711e83