### PR TITLE
Handle unconnected favorites

### DIFF
--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -15,6 +15,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   StreamSubscription<List<String>>? _favSub;
   List<Map<String, dynamic>> _favoriteUsers = [];
   bool _loading = true;
+  bool _loggedIn = true;
 
   @override
   void initState() {
@@ -24,7 +25,13 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
 
   void _listenFavorites() {
     final uid = FirebaseAuth.instance.currentUser?.uid;
-    if (uid == null) return;
+    if (uid == null) {
+      setState(() {
+        _loading = false;
+        _loggedIn = false;
+      });
+      return;
+    }
     _favSub = _favoriteService.favoritesStream(uid).listen((uids) {
       _fetchUsers(uids);
     });
@@ -74,9 +81,13 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
       appBar: AppBar(title: const Text('Mes favoris')),
       body: _loading
           ? const Center(child: CircularProgressIndicator())
-          : _favoriteUsers.isEmpty
-              ? const Center(child: Text('Aucun favori.'))
-              : ListView.builder(
+          : !_loggedIn
+              ? const Center(
+                  child: Text('Veuillez vous connecter pour voir vos favoris.'),
+                )
+              : _favoriteUsers.isEmpty
+                  ? const Center(child: Text('Aucun favori.'))
+                  : ListView.builder(
                   itemCount: _favoriteUsers.length,
                   itemBuilder: (context, index) {
                     final user = _favoriteUsers[index];


### PR DESCRIPTION
## Summary
- handle when favorites screen is opened while user is not logged in
- show message instructing user to login to see favorites

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c9524088832d8b269245114ec8b0