### PR TITLE
Link favorites to home & duel

### DIFF
--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -1,7 +1,12 @@
+import 'dart:async';
+import 'dart:convert';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
 import '../services/favorite_service.dart';
+import 'classement/classement_perso_screen.dart';
+import 'duel_screens/domain_selection_screen.dart';
 
 class FavoritesScreen extends StatefulWidget {
   const FavoritesScreen({Key? key}) : super(key: key);
@@ -15,6 +20,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   StreamSubscription<List<String>>? _favSub;
   List<Map<String, dynamic>> _favoriteUsers = [];
   bool _loading = true;
+  bool _isSendingRequest = false;
 
   @override
   void initState() {
@@ -24,7 +30,10 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
 
   void _listenFavorites() {
     final uid = FirebaseAuth.instance.currentUser?.uid;
-    if (uid == null) return;
+    if (uid == null) {
+      setState(() => _loading = false);
+      return;
+    }
     _favSub = _favoriteService.favoritesStream(uid).listen((uids) {
       _fetchUsers(uids);
     });
@@ -62,6 +71,105 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
     await _favoriteService.removeFavorite(currentUser.uid, uid);
   }
 
+  Future<void> _sendDuelRequest(String opponentId, String opponentPseudo) async {
+    if (_isSendingRequest) return;
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (opponentId == currentUser?.uid) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Vous ne pouvez pas vous défier vous-même.'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    setState(() => _isSendingRequest = true);
+
+    if (currentUser == null) return;
+
+    final selectedDomains = await Navigator.push(
+      context,
+      MaterialPageRoute(builder: (_) => DomainSelectionScreen()),
+    );
+
+    if (selectedDomains == null || selectedDomains.length != 6) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Vous devez choisir exactement 6 domaines.'),
+          backgroundColor: Colors.red,
+        ),
+      );
+      setState(() => _isSendingRequest = false);
+      return;
+    }
+
+    final myId = currentUser.uid;
+    final mySnapshot = await FirebaseFirestore.instance.collection('users').doc(myId).get();
+    final myPseudo = mySnapshot.data()?['pseudo'] ?? 'Joueur';
+
+    List<Map<String, dynamic>> allQuestions = [];
+    Future<List<dynamic>> loadJson(String path) async {
+      final String jsonString = await rootBundle.loadString(path);
+      return json.decode(jsonString);
+    }
+
+    final difficultyMap = {
+      'Facile': 4,
+      'Moyen': 4,
+      'Difficile': 4,
+    };
+
+    for (final difficulty in difficultyMap.keys) {
+      final filteredDomains = List<String>.from(selectedDomains);
+      filteredDomains.shuffle();
+
+      for (final domain in filteredDomains) {
+        if (allQuestions.where((q) => q['difficulte'] == difficulty).length >= difficultyMap[difficulty]!) break;
+
+        final questions = await loadJson('assets/data/$domain.json');
+        final filtered = (questions as List).where((q) => q['difficulte'] == difficulty).toList();
+        filtered.shuffle();
+        if (filtered.isNotEmpty) {
+          allQuestions.add(filtered.first);
+        }
+      }
+    }
+
+    final duelData = {
+      'from': myId,
+      'to': opponentId,
+      'status': 'pending',
+      'createdAt': FieldValue.serverTimestamp(),
+      'questions': allQuestions,
+      'domainesEnvoyeur': selectedDomains,
+      'player1': {
+        'uid': myId,
+        'pseudo': myPseudo,
+        'score': 0,
+        'currentIndex': 0,
+      },
+      'player2': {
+        'uid': opponentId,
+        'pseudo': opponentPseudo,
+        'score': 0,
+        'currentIndex': 0,
+      },
+      'participants': [myId, opponentId],
+    };
+
+    await FirebaseFirestore.instance.collection('duels').add(duelData);
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Défi envoyé avec succès !'),
+        backgroundColor: Colors.green,
+      ),
+    );
+
+    setState(() => _isSendingRequest = false);
+  }
+
   @override
   void dispose() {
     _favSub?.cancel();
@@ -81,15 +189,45 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
                   itemBuilder: (context, index) {
                     final user = _favoriteUsers[index];
                     return ListTile(
-                      leading: CircleAvatar(
-                        backgroundImage: AssetImage(
-                          'assets/images/avatars/${user['avatar']}',
+                      leading: GestureDetector(
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => ClassementPersoScreen(userId: user['uid']),
+                            ),
+                          );
+                        },
+                        child: CircleAvatar(
+                          backgroundImage: AssetImage('assets/images/avatars/${user['avatar']}'),
                         ),
                       ),
                       title: Text(user['pseudo']),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.delete_outline),
-                        onPressed: () => _removeFavorite(user['uid']),
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.delete_outline),
+                            onPressed: () => _removeFavorite(user['uid']),
+                          ),
+                          InkWell(
+                            onTap: () => _sendDuelRequest(user['uid'], user['pseudo']),
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                              decoration: BoxDecoration(
+                                image: const DecorationImage(
+                                  image: AssetImage('assets/images/boiscartoon.png'),
+                                  fit: BoxFit.cover,
+                                ),
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              child: const Text(
+                                'Défier',
+                                style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     );
                   },

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -15,6 +15,7 @@ import '/screens/etude_questions.dart';
 import 'signalements_questions_screen.dart';
 import '/screens/proposition_question_screen.dart';
 import '/screens/questions_selection_screen.dart';
+import 'favorites_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   final User user;
@@ -361,6 +362,17 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                   Navigator.push(
                     context,
                     MaterialPageRoute(builder: (context) => PropositionQuestionScreen()),
+                  );
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.star, color: Colors.orangeAccent),
+                title: Text('Mes favoris'),
+                onTap: () {
+                  Navigator.pop(context);
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(builder: (context) => const FavoritesScreen()),
                   );
                 },
               ),


### PR DESCRIPTION
## Summary
- expose `FavoritesScreen` from the home settings menu
- allow visiting user profiles from the favorites list
- start duels from `FavoritesScreen`
- handle disconnected users in favorites

## Testing
- `flutter format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6849c441afe8832d89d8fe9f65751fcd