### PR TITLE
Fix favorites screen missing state

### DIFF
--- a/lib/screens/favorites_screen.dart
+++ b/lib/screens/favorites_screen.dart
@@ -22,6 +22,7 @@ class _FavoritesScreenState extends State<FavoritesScreen> {
   bool _loading = true;
 
   bool _loggedIn = true;
+  bool _isSendingRequest = false;
 
   @override
   void initState() {


### PR DESCRIPTION
## Summary
- add `_isSendingRequest` state tracking in `FavoritesScreen`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cfec399c832dbf5321ab00aaed53