### PR TITLE
Add favorites button to duel menu

### DIFF
--- a/lib/screens/duel_screens/duel_menu_screen.dart
+++ b/lib/screens/duel_screens/duel_menu_screen.dart
@@ -6,6 +6,7 @@ import '/screens/home_screen.dart';
 import 'duel_user_list_screen.dart';
 import 'duel_dashboard_screen.dart';
 import 'accepted_duels_screen.dart';
+import '../favorites_screen.dart';
 
 
 class DuelMenuScreen extends StatefulWidget {
@@ -146,6 +147,17 @@ class _DuelMenuScreenState extends State<DuelMenuScreen> with SingleTickerProvid
                     );
                   },
                   label: 'Duels à jouer',
+                  backgroundColor: Colors.blueAccent,
+                ),
+                _CustomButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const FavoritesScreen()),
+                    );
+                  },
+                  label: 'Mes favoris',
                   backgroundColor: Colors.blueAccent,
                 ),
                 const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- import favorites screen in DuelMenuScreen
- add a button to access favorites from duel menu

## Testing
- `flutter test test/auth_service_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad1abe728832da071f096e26ef4a3