### PR TITLE
Corrige import en double dans home_screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -8,7 +8,6 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '/screens/defisQuiz_menu_screen.dart';
 import '/screens/classic_quiz/classic_quiz_menu_screen.dart';
 import 'package:lottie/lottie.dart';
-import '/screens/classic_quiz/classic_quiz_menu_screen.dart';
 import '/screens/duel_screens/duel_menu_screen.dart';
 import '/screens/classement/classement_screen.dart';
 import '/screens/etude_questions.dart';


### PR DESCRIPTION
## Résumé
- suppression d'un doublon d'import dans `home_screen.dart`

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_684b0631dbe8832da0260a7f05342015