### PR TITLE
Ajout du signalement de problème dans les quiz classiques

### DIFF
--- a/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
@@ -209,14 +209,14 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
     });
   }
 
-  void _checkAnswer(bool isCorrect, String explanation) async {
+  void _checkAnswer(bool isCorrect, Map<String, dynamic> question) async {
     if (_answered) return;
 
     _playGunSound(); // 🔫 Joue le son du tir
 
     setState(() {
       _answered = true;
-      _explanation = explanation;
+      _explanation = question['explication'];
       if (isCorrect) {
         _score++;
         _controller.stop();
@@ -304,7 +304,7 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
                         ),
                         SizedBox(height: 12),
                         Text(
-                          explanation,
+                          _explanation ?? '',
                           style: GoogleFonts.poppins(
                             fontSize: 16,
                             color: Colors.black87,
@@ -314,6 +314,12 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
                       ],
                     ),
                   ),
+                ),
+                SizedBox(height: 12),
+                TextButton.icon(
+                  onPressed: () => _signalerProbleme(question),
+                  icon: const Icon(Icons.report_problem_outlined),
+                  label: const Text('Signaler un problème'),
                 ),
                 SizedBox(height: 24),
                 Container(
@@ -490,7 +496,7 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
                   }
 
                   _showImpactsOnButton(panelKey, i, details);
-                  _checkAnswer(isCorrect, currentQuestion['explication']);
+                  _checkAnswer(isCorrect, currentQuestion as Map<String, dynamic>);
                   setState(() {
                     selectedIndex = i;
                   });
@@ -578,6 +584,51 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
     } catch (e) {
       debugPrint("Erreur de lecture du son de tir : $e");
     }
+  }
+
+  void _signalerProbleme(Map<String, dynamic> question) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        TextEditingController controller = TextEditingController();
+        return AlertDialog(
+          title: const Text('Signaler un problème'),
+          content: TextField(
+            controller: controller,
+            maxLines: 5,
+            decoration: const InputDecoration(
+              hintText: 'Décrivez le problème rencontré avec cette question',
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                final message = controller.text.trim();
+                if (message.isNotEmpty) {
+                  await FirebaseFirestore.instance
+                      .collection('signalements_questions')
+                      .add({
+                    'timestamp': Timestamp.now(),
+                    'question': question['question'],
+                    'categorie': question['categorie'],
+                    'explication': question['explication'],
+                    'reponses': question['reponses'],
+                    'message': message,
+                  });
+                }
+                Navigator.of(context).pop();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Merci ! Le problème a été signalé.'),
+                  ),
+                );
+              },
+              child: const Text('Envoyer'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override

--- a/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
@@ -209,14 +209,14 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
     });
   }
 
-  void _checkAnswer(bool isCorrect, String explanation) async {
+  void _checkAnswer(bool isCorrect, Map<String, dynamic> question) async {
     if (_answered) return;
 
     _playGunSound(); // 🔫 Joue le son du tir
 
     setState(() {
       _answered = true;
-      _explanation = explanation;
+      _explanation = question['explication'];
       if (isCorrect) {
         _score++;
         _controller.stop();
@@ -304,7 +304,7 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
                         ),
                         SizedBox(height: 12),
                         Text(
-                          explanation,
+                          _explanation ?? '',
                           style: GoogleFonts.poppins(
                             fontSize: 16,
                             color: Colors.black87,
@@ -314,6 +314,12 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
                       ],
                     ),
                   ),
+                ),
+                SizedBox(height: 12),
+                TextButton.icon(
+                  onPressed: () => _signalerProbleme(question),
+                  icon: const Icon(Icons.report_problem_outlined),
+                  label: const Text('Signaler un problème'),
                 ),
                 SizedBox(height: 24),
                 Container(
@@ -490,7 +496,7 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
                   }
 
                   _showImpactsOnButton(panelKey, i, details);
-                  _checkAnswer(isCorrect, currentQuestion['explication']);
+                  _checkAnswer(isCorrect, currentQuestion as Map<String, dynamic>);
                   setState(() {
                     selectedIndex = i;
                   });
@@ -578,6 +584,51 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
     } catch (e) {
       debugPrint("Erreur de lecture du son de tir : $e");
     }
+  }
+
+  void _signalerProbleme(Map<String, dynamic> question) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        TextEditingController controller = TextEditingController();
+        return AlertDialog(
+          title: const Text('Signaler un problème'),
+          content: TextField(
+            controller: controller,
+            maxLines: 5,
+            decoration: const InputDecoration(
+              hintText: 'Décrivez le problème rencontré avec cette question',
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                final message = controller.text.trim();
+                if (message.isNotEmpty) {
+                  await FirebaseFirestore.instance
+                      .collection('signalements_questions')
+                      .add({
+                    'timestamp': Timestamp.now(),
+                    'question': question['question'],
+                    'categorie': question['categorie'],
+                    'explication': question['explication'],
+                    'reponses': question['reponses'],
+                    'message': message,
+                  });
+                }
+                Navigator.of(context).pop();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Merci ! Le problème a été signalé.'),
+                  ),
+                );
+              },
+              child: const Text('Envoyer'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override

--- a/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
@@ -166,6 +166,51 @@ class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScree
     );
   }
 
+  void _signalerProbleme(Map<String, dynamic> question) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        TextEditingController controller = TextEditingController();
+        return AlertDialog(
+          title: const Text('Signaler un problème'),
+          content: TextField(
+            controller: controller,
+            maxLines: 5,
+            decoration: const InputDecoration(
+              hintText: 'Décrivez le problème rencontré avec cette question',
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                final message = controller.text.trim();
+                if (message.isNotEmpty) {
+                  await FirebaseFirestore.instance
+                      .collection('signalements_questions')
+                      .add({
+                    'timestamp': Timestamp.now(),
+                    'question': question['question'],
+                    'categorie': question['categorie'],
+                    'explication': question['explication'],
+                    'reponses': question['reponses'],
+                    'message': message,
+                  });
+                }
+                Navigator.of(context).pop();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Merci ! Le problème a été signalé.'),
+                  ),
+                );
+              },
+              child: const Text('Envoyer'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   Widget _buildVerticalScoreBar() {
     return Align(
       alignment: Alignment.centerRight,

--- a/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
@@ -208,14 +208,14 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
     });
   }
 
-  void _checkAnswer(bool isCorrect, String explanation) async {
+  void _checkAnswer(bool isCorrect, Map<String, dynamic> question) async {
     if (_answered) return;
 
     _playGunSound(); // 🔫 Joue le son du tir
 
     setState(() {
       _answered = true;
-      _explanation = explanation;
+      _explanation = question['explication'];
       if (isCorrect) {
         _score++;
         _controller.stop();
@@ -303,7 +303,7 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
                         ),
                         SizedBox(height: 12),
                         Text(
-                          explanation,
+                          _explanation ?? '',
                           style: GoogleFonts.poppins(
                             fontSize: 16,
                             color: Colors.black87,
@@ -313,6 +313,12 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
                       ],
                     ),
                   ),
+                ),
+                SizedBox(height: 12),
+                TextButton.icon(
+                  onPressed: () => _signalerProbleme(question),
+                  icon: const Icon(Icons.report_problem_outlined),
+                  label: const Text('Signaler un problème'),
                 ),
                 SizedBox(height: 24),
                 Container(
@@ -489,7 +495,7 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
                         }
 
                         _showImpactsOnButton(panelKey, i, details);
-                        _checkAnswer(isCorrect, currentQuestion['explication']);
+                        _checkAnswer(isCorrect, currentQuestion as Map<String, dynamic>);
                         setState(() {
                           selectedIndex = i;
                         });
@@ -577,6 +583,51 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
     } catch (e) {
       debugPrint("Erreur de lecture du son de tir : $e");
     }
+  }
+
+  void _signalerProbleme(Map<String, dynamic> question) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        TextEditingController controller = TextEditingController();
+        return AlertDialog(
+          title: const Text('Signaler un problème'),
+          content: TextField(
+            controller: controller,
+            maxLines: 5,
+            decoration: const InputDecoration(
+              hintText: 'Décrivez le problème rencontré avec cette question',
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () async {
+                final message = controller.text.trim();
+                if (message.isNotEmpty) {
+                  await FirebaseFirestore.instance
+                      .collection('signalements_questions')
+                      .add({
+                    'timestamp': Timestamp.now(),
+                    'question': question['question'],
+                    'categorie': question['categorie'],
+                    'explication': question['explication'],
+                    'reponses': question['reponses'],
+                    'message': message,
+                  });
+                }
+                Navigator.of(context).pop();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Merci ! Le problème a été signalé.'),
+                  ),
+                );
+              },
+              child: const Text('Envoyer'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary
- ajout d'une méthode `_signalerProbleme` dans chaque écran de quiz classique
- ajout d'un bouton pour signaler un problème dans la boîte d'explication des quiz (hors géographie)
- passage de la question complète à `_checkAnswer` pour pouvoir signaler

## Testing
- `flutter --version` *(échec : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_684b461b4f14832dae5f5b4fc837bc86