### PR TITLE
Intégration des publicités AdMob

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
         android:label="corsicaquiz"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-4176691748354941~7193192759"/>
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -66,6 +66,8 @@
         <key>REVERSED_CLIENT_ID</key>
         <string>com.googleusercontent.apps.109788230031-p59g4m2378mcirc3jr9kf4ipsddlm5fi</string>
     </dict>
+    <key>GADApplicationIdentifier</key>
+    <string>ca-app-pub-4176691748354941~7193192759</string>
     <key>NSFaceIDUsageDescription</key>
     <string>Utilisation de Face ID pour se connecter avec Apple.</string>
     <key>NSAppTransportSecurity</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import '/screens/splash_screen.dart'; // Import du splash screen
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '/services/winner_service.dart';
 import 'services/notification_service.dart';
+import 'services/ad_service.dart';
 import 'theme_notifier.dart';
 
 void main() async {
@@ -16,6 +17,7 @@ void main() async {
   );
   await NotificationService.init();
   await ThemeNotifier.loadTheme();
+  await AdService.init();
 
   runApp(const MyApp());
 }

--- a/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
@@ -9,6 +9,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '/screens/classic_quiz/classic_quiz_menu_screen.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
+import '/services/ad_service.dart';
 
 
 class ClassicCultureQuizScreen extends StatefulWidget {
@@ -62,6 +63,7 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
                 SizedBox(height: 20),
                 ElevatedButton(
                   onPressed: () {
+                    AdService.showInterstitial();
                     Navigator.pop(context);
                     Navigator.pushReplacement(
                       context,

--- a/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
@@ -9,6 +9,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '/screens/classic_quiz/classic_quiz_menu_screen.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
+import '/services/ad_service.dart';
 
 
 class ClassicFauneQuizScreen extends StatefulWidget {
@@ -62,6 +63,7 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
                 SizedBox(height: 20),
                 ElevatedButton(
                   onPressed: () {
+                    AdService.showInterstitial();
                     Navigator.pop(context);
                     Navigator.pushReplacement(
                       context,

--- a/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
@@ -8,6 +8,7 @@ import 'package:latlong2/latlong.dart' as latlong2;
 import 'package:lottie/lottie.dart';
 import 'package:just_audio/just_audio.dart';
 import 'classic_quiz_menu_screen.dart';
+import '/services/ad_service.dart';
 
 class ClassicGeographieQuizScreen extends StatefulWidget {
   ClassicGeographieQuizScreen({super.key});
@@ -151,6 +152,7 @@ class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScree
               SizedBox(height: 20),
               ElevatedButton(
                 onPressed: () {
+                  AdService.showInterstitial();
                   Navigator.pop(context);
                   Navigator.pushReplacement(
                     context,

--- a/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
@@ -9,6 +9,7 @@ import 'package:just_audio/just_audio.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '/screens/classic_quiz/classic_quiz_menu_screen.dart';
+import '/services/ad_service.dart';
 
 class ClassicHistoireQuizScreen extends StatefulWidget {
   @override
@@ -61,6 +62,7 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
                 SizedBox(height: 20),
                 ElevatedButton(
                   onPressed: () {
+                    AdService.showInterstitial();
                     Navigator.pop(context);
                     Navigator.pushReplacement(
                       context,

--- a/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
@@ -8,6 +8,7 @@ import 'package:just_audio/just_audio.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '/screens/classic_quiz/classic_quiz_menu_screen.dart';
+import '/services/ad_service.dart';
 
 class ClassicPersonnalitesQuizScreen extends StatefulWidget {
   @override
@@ -61,6 +62,7 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
                 SizedBox(height: 20),
                 ElevatedButton(
                   onPressed: () {
+                    AdService.showInterstitial();
                     Navigator.pop(context);
                     Navigator.pushReplacement(
                       context,

--- a/lib/screens/defis_screens/defi_quiz_screen.dart
+++ b/lib/screens/defis_screens/defi_quiz_screen.dart
@@ -10,6 +10,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
+import '/services/ad_service.dart';
 
 
 class HistoryQuizScreen extends StatefulWidget {
@@ -378,6 +379,7 @@ class _HistoryQuizScreenState extends State<HistoryQuizScreen> with TickerProvid
                     'duration': 60, // durée initiale
                     'questions_answered': _askedQuestions.length,
                   }).then((_) {
+                    AdService.showInterstitial();
                     Navigator.of(context).popUntil((route) => route.isFirst);
                     Navigator.pushReplacementNamed(context, '/defis_quiz_menu');
                   });

--- a/lib/screens/duel_screens/duel_result_screen.dart
+++ b/lib/screens/duel_screens/duel_result_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart' show rootBundle;
 import 'domain_selection_screen.dart';
 import 'duel_game_screen.dart';
 import '../../services/duel_service.dart';
+import '/services/ad_service.dart';
 
 class DuelResultScreen extends StatefulWidget {
   final String duelId;
@@ -445,7 +446,10 @@ class _DuelResultScreenState extends State<DuelResultScreen> {
                           SizedBox(
                             width: double.infinity,
                             child: ElevatedButton.icon(
-                              onPressed: () => Navigator.popUntil(context, (route) => route.isFirst),
+                              onPressed: () {
+                                AdService.showInterstitial();
+                                Navigator.popUntil(context, (route) => route.isFirst);
+                              },
                               icon: const Icon(Icons.home),
                               label: const Text('Retour à l\'accueil'),
                               style: ElevatedButton.styleFrom(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -5,6 +5,8 @@ import 'dart:io';
 import '/services/profile_service.dart';
 import '../screens/home_screen.dart';
 import '../screens/profile_screen.dart';
+import '/services/ad_service.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 
 class LoginScreen extends StatefulWidget {
   final AuthService? authService;
@@ -20,11 +22,18 @@ class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   bool _isLoading = false; // Indicateur de chargement
+  BannerAd? _bannerAd;
+  bool _bannerLoaded = false;
 
   @override
   void initState() {
     super.initState();
     _authService = widget.authService ?? AuthService();
+    _bannerAd = AdService.createBanner(() {
+      setState(() {
+        _bannerLoaded = true;
+      });
+    });
   }
 
   void _handleAuth() async {
@@ -363,7 +372,21 @@ class _LoginScreenState extends State<LoginScreen> {
           ),
         ),
       ),
+      bottomNavigationBar: _bannerLoaded && _bannerAd != null
+          ? SizedBox(
+              height: _bannerAd!.size.height.toDouble(),
+              child: AdWidget(ad: _bannerAd!),
+            )
+          : null,
     );
+  }
+
+  @override
+  void dispose() {
+    _bannerAd?.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
   }
 
   // ✅ Widget pour un champ de texte stylisé

--- a/lib/services/ad_service.dart
+++ b/lib/services/ad_service.dart
@@ -1,0 +1,61 @@
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:flutter/material.dart';
+
+class AdService {
+  static const String bannerTestId = 'ca-app-pub-3940256099942544/4411468910';
+
+  static InterstitialAd? _interstitial;
+  static bool _interstitialReady = false;
+
+  static Future<void> init() async {
+    await MobileAds.instance.initialize();
+    loadInterstitial();
+  }
+
+  static void loadInterstitial() {
+    InterstitialAd.load(
+      adUnitId: InterstitialAd.testAdUnitId,
+      request: const AdRequest(),
+      adLoadCallback: InterstitialAdLoadCallback(
+        onAdLoaded: (ad) {
+          _interstitial = ad;
+          _interstitialReady = true;
+        },
+        onAdFailedToLoad: (error) {
+          _interstitialReady = false;
+        },
+      ),
+    );
+  }
+
+  static void showInterstitial() {
+    if (_interstitialReady && _interstitial != null) {
+      _interstitial!.fullScreenContentCallback = FullScreenContentCallback(
+        onAdDismissedFullScreenContent: (ad) {
+          ad.dispose();
+          loadInterstitial();
+        },
+        onAdFailedToShowFullScreenContent: (ad, error) {
+          ad.dispose();
+          loadInterstitial();
+        },
+      );
+      _interstitial!.show();
+      _interstitialReady = false;
+    }
+  }
+
+  static BannerAd createBanner(VoidCallback onLoaded) {
+    final banner = BannerAd(
+      adUnitId: bannerTestId,
+      size: AdSize.banner,
+      request: const AdRequest(),
+      listener: BannerAdListener(
+        onAdLoaded: (ad) => onLoaded(),
+        onAdFailedToLoad: (ad, error) => ad.dispose(),
+      ),
+    );
+    banner.load();
+    return banner;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   latlong2: ^0.9.0
   package_info_plus: ^8.3.0
   shared_preferences: ^2.2.2
+  google_mobile_ads: ^5.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- ajoute la dépendance `google_mobile_ads`
- crée `AdService` pour initialiser les pubs et gérer bannière et interstitiel
- initialise `AdService` dans `main.dart`
- affiche une bannière de test dans `LoginScreen`
- déclenche un interstitiel au retour au menu des quiz
- configure l'`App ID` AdMob pour Android et iOS

## Testing
- `flutter test` *(échoue : `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684b48b1fd58832d9b44c50b8f12e9c2