### PR TITLE
Ajout service musique de fond

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '/services/winner_service.dart';
 import 'services/notification_service.dart';
 import 'services/ad_service.dart';
+import 'services/background_music_service.dart';
 import 'theme_notifier.dart';
 
 void main() async {
@@ -18,6 +19,7 @@ void main() async {
   await NotificationService.init();
   await ThemeNotifier.loadTheme();
   await AdService.init();
+  await BackgroundMusicService.instance.play();
 
   runApp(const MyApp());
 }

--- a/lib/screens/defis_screens/defi_quiz_screen.dart
+++ b/lib/screens/defis_screens/defi_quiz_screen.dart
@@ -62,7 +62,6 @@ class _HistoryQuizScreenState extends State<HistoryQuizScreen> with TickerProvid
     _loadQuestions();
     _audioPlayer = AudioPlayer();
     _audioPlayer.setReleaseMode(ReleaseMode.loop);
-    _audioPlayer.play(AssetSource('sons/quiz/quizmusic.mp3'));
     _timerSound.setReleaseMode(ReleaseMode.loop);
     _scorePulseController = AnimationController(
       vsync: this,

--- a/lib/screens/duel_screens/duel_game_screen.dart
+++ b/lib/screens/duel_screens/duel_game_screen.dart
@@ -45,9 +45,7 @@ void initState() {
       .chain(CurveTween(curve: Curves.elasticIn))
       .animate(_shakeController);
 
-  player.setAsset('assets/sons/quiz/quizmusic.mp3');
   player.setLoopMode(LoopMode.one);
-  player.play();
   _loadDuel();
 }
 
@@ -190,9 +188,6 @@ void initState() {
     await player.setAsset('assets/sons/quiz/woosh.mp3');
     await player.play();
     await Future.delayed(Duration(milliseconds: 300));
-
-    await player.setAsset('assets/sons/quiz/quizmusic.mp3');
-    player.play();
 
     setState(() {
       currentIndex++;

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../services/auth_service.dart';
 import '../services/notification_service.dart';
+import '../services/background_music_service.dart';
 import '../theme_notifier.dart';
 import 'about_screen.dart';
 import 'etude_questions.dart';
@@ -26,6 +27,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   final AuthService _auth = AuthService();
   bool _incognito = false;
   bool _notifications = true;
+  bool _music = true;
 
   @override
   void initState() {
@@ -43,6 +45,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     }
     final prefs = await SharedPreferences.getInstance();
     _notifications = prefs.getBool('notifications_enabled') ?? true;
+    _music = prefs.getBool('music_enabled') ?? true;
     setState(() {});
   }
 
@@ -62,6 +65,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
       await NotificationService.init();
     } else {
       await NotificationService.disable();
+    }
+  }
+
+  Future<void> _toggleMusic(bool value) async {
+    setState(() => _music = value);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('music_enabled', value);
+    if (value) {
+      await BackgroundMusicService.instance.play();
+    } else {
+      await BackgroundMusicService.instance.pause();
     }
   }
 
@@ -152,6 +166,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: const Text('Notifications'),
             value: _notifications,
             onChanged: _toggleNotifications,
+          ),
+          SwitchListTile(
+            title: const Text('Musique de fond'),
+            value: _music,
+            onChanged: _toggleMusic,
           ),
           SwitchListTile(
             title: const Text('Thème sombre'),

--- a/lib/services/background_music_service.dart
+++ b/lib/services/background_music_service.dart
@@ -1,0 +1,41 @@
+import 'package:just_audio/just_audio.dart';
+
+class BackgroundMusicService {
+  BackgroundMusicService._();
+
+  static final BackgroundMusicService instance = BackgroundMusicService._();
+
+  final AudioPlayer _player = AudioPlayer();
+  bool _initialized = false;
+  bool _enabled = true;
+
+  Future<void> play() async {
+    if (!_enabled) return;
+    if (!_initialized) {
+      await _player.setLoopMode(LoopMode.all);
+      await _player.setAsset('assets/sons/musique.mp3');
+      _initialized = true;
+    }
+    await _player.play();
+  }
+
+  Future<void> pause() => _player.pause();
+
+  Future<void> resume() => _enabled ? _player.play() : Future.value();
+
+  Future<void> stop() async {
+    await _player.stop();
+    _initialized = false;
+  }
+
+  bool get enabled => _enabled;
+
+  set enabled(bool value) {
+    _enabled = value;
+    if (_enabled) {
+      play();
+    } else {
+      _player.pause();
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -102,6 +102,7 @@ flutter:
    - assets/data/questions_geographie.json
    - assets/images/avatars/
    - assets/lottie/
+   - assets/sons/
    - assets/sons/quiz/
    - assets/videos/
 


### PR DESCRIPTION
## Summary
- créer `BackgroundMusicService` basé sur `just_audio`
- lancer la musique au démarrage de l'application
- ajouter un interrupteur dans `SettingsScreen` pour activer la musique de fond
- supprimer les lectures directes de musique dans les écrans de quiz
- déclarer le dossier `assets/sons/` dans `pubspec.yaml`

## Testing
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_684be3cf51a8832dafd48a60f461a3b1