### PR TITLE
Fix Android build configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,7 +10,9 @@ plugins {
 // 🔐 Chargement des propriétés de signature
 val keystoreProperties = Properties()
 val keystorePropertiesFile = rootProject.file("key.properties")
-keystoreProperties.load(keystorePropertiesFile.inputStream())
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(keystorePropertiesFile.inputStream())
+}
 
 android {
     namespace = "com.msj2025.corsicaquiz"
@@ -20,6 +22,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true // active la désugarisation
     }
 
     kotlinOptions {
@@ -35,11 +38,13 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = file(keystoreProperties["storeFile"] as String)
-            storePassword = keystoreProperties["storePassword"] as String
+        if (keystoreProperties.isNotEmpty()) {
+            create("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+            }
         }
     }
 
@@ -51,7 +56,7 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
-            signingConfig = signingConfigs.getByName("release")
+            signingConfigs.findByName("release")?.let { signingConfig = it }
         }
     }
 }
@@ -59,3 +64,9 @@ android {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    // autres dépendances éventuelles
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
+}
+

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     // START: FlutterFire Configuration
     id("com.google.gms.google-services") version("4.3.15") apply false
     // END: FlutterFire Configuration
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.21" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Summary
- make keystore optional in gradle script
- enable desugaring support and add desugar library
- bump Kotlin plugin to `2.0.21`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dd9e036d4832d8d7e20046a84f7f5