### PR TITLE
Ajout de vérification mounted avant setState

### DIFF
--- a/lib/screens/defis_screens/defi_quiz_screen.dart
+++ b/lib/screens/defis_screens/defi_quiz_screen.dart
@@ -277,6 +277,7 @@ class _HistoryQuizScreenState extends State<HistoryQuizScreen> with TickerProvid
     _scorePulseController.forward(from: 0.0);
 
     Future.delayed(Duration(seconds: 1), () {
+      if (!mounted) return;
       setState(() {
         _showAnimation = false;
         if (_timeLeft > 0) {
@@ -300,6 +301,7 @@ class _HistoryQuizScreenState extends State<HistoryQuizScreen> with TickerProvid
     });
 
     Future.delayed(Duration(milliseconds: 800), () {
+      if (!mounted) return;
       setState(() {
         _timerHighlight = false;
       });


### PR DESCRIPTION
## Notes
- Les commandes de test `flutter` ne sont pas disponibles dans l'environnement actuel.

## Résumé
- Ajout de `if (!mounted) return;` avant chaque `setState` dans les callbacks différés du quiz pour éviter un appel après la destruction du widget.


------
https://chatgpt.com/codex/tasks/task_e_684ff18f1a98832d8965a47c727c9bca