### PR TITLE
Ajout de tests pour les services

### DIFF
--- a/test/ad_service_test.dart
+++ b/test/ad_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:corsicaquiz/services/ad_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('plugins.flutter.io/google_mobile_ads');
+
+  setUp(() {
+    channel.setMockMethodCallHandler((MethodCall methodCall) async => null);
+  });
+
+  tearDown(() {
+    channel.setMockMethodCallHandler(null);
+  });
+
+  test('init ne lance pas d\'exception', () async {
+    await AdService.init();
+  });
+
+  test('loadInterstitial gère les erreurs sans exception', () async {
+    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      throw PlatformException(code: '0', message: 'error');
+    });
+    expect(() => AdService.loadInterstitial(), returnsNormally);
+  });
+}

--- a/test/background_music_service_test.dart
+++ b/test/background_music_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:corsicaquiz/services/background_music_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel('com.ryanheise.just_audio');
+
+  setUp(() {
+    channel.setMockMethodCallHandler((MethodCall methodCall) async => null);
+  });
+
+  tearDown(() {
+    channel.setMockMethodCallHandler(null);
+  });
+
+  test('play initialise le service sans erreur', () async {
+    await BackgroundMusicService.instance.play();
+  });
+
+  test('enabled permet d\'activer et désactiver la musique', () async {
+    BackgroundMusicService.instance.enabled = false;
+    await BackgroundMusicService.instance.play();
+    BackgroundMusicService.instance.enabled = true;
+    await BackgroundMusicService.instance.play();
+  });
+}

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:corsicaquiz/services/notification_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const notifChannel = MethodChannel('dexterous.com/flutter/local_notifications');
+  const firebaseChannel = MethodChannel('plugins.flutter.io/firebase_messaging');
+
+  setUp(() {
+    notifChannel.setMockMethodCallHandler((MethodCall methodCall) async => null);
+    firebaseChannel.setMockMethodCallHandler((MethodCall methodCall) async => null);
+  });
+
+  tearDown(() {
+    notifChannel.setMockMethodCallHandler(null);
+    firebaseChannel.setMockMethodCallHandler(null);
+  });
+
+  test('init ne lance pas d\'exception', () async {
+    await NotificationService.init();
+  });
+
+  test('disable ne lance pas d\'exception', () async {
+    await NotificationService.disable();
+  });
+}


### PR DESCRIPTION
## Résumé
- ajout de tests unitaires pour `AdService`
- ajout de tests unitaires pour `NotificationService`
- ajout de tests unitaires pour `BackgroundMusicService`

## Test
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_684ff1906970832dbb039e91908f3ea7