### PR TITLE
Fix city field in geography quiz

### DIFF
--- a/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
@@ -369,7 +369,7 @@ class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScree
                     color: Colors.white.withOpacity(0.8),
                     borderRadius: BorderRadius.circular(12),
                   ),
-                  child: Text('Où se situe ${city['ville']} ?'),
+                  child: Text('Où se situe ${city['nom']} ?'),
                 ),
                 SizedBox(height: 8),
                 Text('Score : $_score / 12', style: TextStyle(color: Colors.white)),


### PR DESCRIPTION
## Summary
- show the location name using `city['nom']` in geography quiz

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509d3781c4832d971b89ef2edafb4f