### PR TITLE
Corrige chemin fichier questions histoire

### DIFF
--- a/lib/services/question_service.dart
+++ b/lib/services/question_service.dart
@@ -3,7 +3,7 @@ import 'package:flutter/services.dart';
 
 class QuestionService {
   Future<List<Map<String, dynamic>>> loadQuestions() async {
-    final String response = await rootBundle.loadString('assets/data/histoire.json');
+    final String response = await rootBundle.loadString('assets/data/questions_histoire.json');
     final List<dynamic> data = json.decode(response);
 
     return data.cast<Map<String, dynamic>>();


### PR DESCRIPTION
## Summary
- charger `assets/data/questions_histoire.json` dans QuestionService

## Testing
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6850a07eb04c832da1e787b297645691