### PR TITLE
Mélange équilibré des villes dans le quiz géographie

### DIFF
--- a/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
@@ -46,11 +46,27 @@ class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScree
   }
 
   Future<void> _loadCities() async {
-    final data = await rootBundle.loadString('assets/data/questions_geographie.json');
+    final data = await rootBundle
+        .loadString('assets/data/questions_geographie.json');
     final allCities = json.decode(data) as List<dynamic>;
-    allCities.shuffle();
+
+    final List<dynamic> easyCities =
+        (allCities.where((c) => c['difficulte'] == 'Facile').toList()..shuffle());
+    final List<dynamic> mediumCities =
+        (allCities.where((c) => c['difficulte'] == 'Moyen').toList()..shuffle());
+    final List<dynamic> hardCities =
+        (allCities.where((c) => c['difficulte'] == 'Difficile').toList()
+          ..shuffle());
+
+    final selectedCities = [
+      ...easyCities.take(4),
+      ...mediumCities.take(4),
+      ...hardCities.take(4)
+    ]
+      ..shuffle();
+
     setState(() {
-      _cities = allCities.take(12).toList();
+      _cities = selectedCities;
     });
   }
 


### PR DESCRIPTION
## Résumé
- réécriture de `_loadCities` pour récupérer 4 villes par niveau de difficulté puis mélanger l'ensemble

## Tests
- `flutter analyze` *(échoue : `flutter` non installé)*
- `flutter test` *(échoue : `flutter` non installé)*

------
https://chatgpt.com/codex/tasks/task_e_685c58350b44832da758239eff436b29