### PR TITLE
Nettoyage des bannières et gestion interstitielle

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -5,8 +5,6 @@ import 'dart:io';
 import '/services/profile_service.dart';
 import '../screens/home_screen.dart';
 import '../screens/profile_screen.dart';
-import '/services/ad_service.dart';
-import 'package:google_mobile_ads/google_mobile_ads.dart';
 
 class LoginScreen extends StatefulWidget {
   final AuthService? authService;
@@ -22,18 +20,11 @@ class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController _emailController = TextEditingController();
   final TextEditingController _passwordController = TextEditingController();
   bool _isLoading = false; // Indicateur de chargement
-  BannerAd? _bannerAd;
-  bool _bannerLoaded = false;
 
   @override
   void initState() {
     super.initState();
     _authService = widget.authService ?? AuthService();
-    _bannerAd = AdService.createBanner(() {
-      setState(() {
-        _bannerLoaded = true;
-      });
-    });
   }
 
   void _handleAuth() async {
@@ -372,18 +363,11 @@ class _LoginScreenState extends State<LoginScreen> {
           ),
         ),
       ),
-      bottomNavigationBar: _bannerLoaded && _bannerAd != null
-          ? SizedBox(
-              height: _bannerAd!.size.height.toDouble(),
-              child: AdWidget(ad: _bannerAd!),
-            )
-          : null,
     );
   }
 
   @override
   void dispose() {
-    _bannerAd?.dispose();
     _emailController.dispose();
     _passwordController.dispose();
     super.dispose();

--- a/lib/services/ad_service.dart
+++ b/lib/services/ad_service.dart
@@ -1,20 +1,33 @@
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:flutter/material.dart';
+import 'dart:io';
 
 class AdService {
-  static const String bannerTestId = 'ca-app-pub-3940256099942544/4411468910';
+  // Identifiant interstitiel de test pour Android
+  // Remplacez-le par votre ID Android lors de la mise en production
+  static const String _interstitialAndroidId =
+      'ca-app-pub-3940256099942544/1033173712';
+
+  // Identifiant interstitiel de test pour iOS
+  // Remplacez-le par votre ID iOS lors de la mise en production
+  static const String _interstitialIosId =
+      'ca-app-pub-3940256099942544/4411468910';
 
   static InterstitialAd? _interstitial;
+  // Indique si l'interstitiel est prêt à être affiché
   static bool _interstitialReady = false;
 
   static Future<void> init() async {
     await MobileAds.instance.initialize();
+    // Charge un interstitiel dès le démarrage de l'application
     loadInterstitial();
   }
 
   static void loadInterstitial() {
     InterstitialAd.load(
-      adUnitId: 'ca-app-pub-3940256099942544/1033173712',
+      // Sélection de l'identifiant adapté à Android ou iOS
+      adUnitId:
+          Platform.isAndroid ? _interstitialAndroidId : _interstitialIosId,
       request: const AdRequest(),
       adLoadCallback: InterstitialAdLoadCallback(
         onAdLoaded: (ad) {
@@ -29,33 +42,27 @@ class AdService {
   }
 
   static void showInterstitial() {
+    // Affiche l'interstitiel s'il est prêt
     if (_interstitialReady && _interstitial != null) {
       _interstitial!.fullScreenContentCallback = FullScreenContentCallback(
         onAdDismissedFullScreenContent: (ad) {
+          // Recharge automatiquement un interstitiel une fois l'affichage terminé
           ad.dispose();
           loadInterstitial();
         },
         onAdFailedToShowFullScreenContent: (ad, error) {
+          // En cas d'erreur d'affichage, on détruit l'instance
+          // et on tente de recharger pour la prochaine fois
           ad.dispose();
           loadInterstitial();
         },
       );
       _interstitial!.show();
+      // L'interstitiel ne peut être réutilisé, on marque donc l'état comme non prêt
       _interstitialReady = false;
     }
   }
 
-  static BannerAd createBanner(VoidCallback onLoaded) {
-    final banner = BannerAd(
-      adUnitId: bannerTestId,
-      size: AdSize.banner,
-      request: const AdRequest(),
-      listener: BannerAdListener(
-        onAdLoaded: (ad) => onLoaded(),
-        onAdFailedToLoad: (ad, error) => ad.dispose(),
-      ),
-    );
-    banner.load();
-    return banner;
-  }
+  // La gestion des bannières publicitaires a été supprimée
+  // car l'application n'en affiche pas.
 }


### PR DESCRIPTION
## Résumé
- suppression du code lié aux bannières publicitaires
- ajout d'une gestion interstitielle commune Android/iOS avec commentaires

## Tests
- `dart format lib/services/ad_service.dart lib/screens/login_screen.dart` *(échec : `dart` introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_685c6b095400832db3001835172e9428