### PR TITLE
Allow guest entry with auth-required quizzes

### DIFF
--- a/lib/screens/classic_quiz/classic_quiz_menu_screen.dart
+++ b/lib/screens/classic_quiz/classic_quiz_menu_screen.dart
@@ -144,7 +144,8 @@ class ClassicQuizMenuScreen extends StatelessWidget {
                       onPressed: () {
                         Navigator.pushAndRemoveUntil(
                           context,
-                          MaterialPageRoute(builder: (context) => HomeScreen(user: FirebaseAuth.instance.currentUser!)),
+                          MaterialPageRoute(
+                              builder: (context) => HomeScreen(user: FirebaseAuth.instance.currentUser)),
                           (route) => false,
                         );
                       },

--- a/lib/screens/defisQuiz_menu_screen.dart
+++ b/lib/screens/defisQuiz_menu_screen.dart
@@ -192,7 +192,8 @@ class _ChallengeScreenState extends State<ChallengeScreen> with SingleTickerProv
                 onPressed: () {
                   Navigator.pushAndRemoveUntil(
                     context,
-                    MaterialPageRoute(builder: (context) => HomeScreen(user: FirebaseAuth.instance.currentUser!)),
+                    MaterialPageRoute(
+                        builder: (context) => HomeScreen(user: FirebaseAuth.instance.currentUser)),
                     (route) => false,
                   );
                 },

--- a/lib/screens/duel_screens/duel_menu_screen.dart
+++ b/lib/screens/duel_screens/duel_menu_screen.dart
@@ -111,7 +111,7 @@ class _DuelMenuScreenState extends State<DuelMenuScreen> with SingleTickerProvid
                     onPressed: () {
                       Navigator.pushAndRemoveUntil(
                         context,
-                        MaterialPageRoute(builder: (context) => HomeScreen(user: FirebaseAuth.instance.currentUser!)),
+                        MaterialPageRoute(builder: (context) => HomeScreen(user: FirebaseAuth.instance.currentUser)),
                         (route) => false,
                       );
                     },

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -3,6 +3,7 @@ import 'package:flame/game.dart';
 import 'package:flame/components.dart';
 import 'package:flame/effects.dart';
 import 'login_screen.dart';
+import 'welcome_screen.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '/services/profile_service.dart';
 import '/services/winner_service.dart'; // Ajout de l'import pour WinnerService
@@ -29,9 +30,15 @@ class _SplashScreenState extends State<SplashScreen> {
     if (!mounted) return;
     if (user != null) {
       PresenceService().init(user.uid);
-      Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => HomeScreen(user: user)));
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => HomeScreen(user: user)),
+      );
     } else {
-      Navigator.pushReplacement(context, MaterialPageRoute(builder: (_) => LoginScreen()));
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (_) => const WelcomeScreen()),
+      );
     }
   }
 

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'login_screen.dart';
+import 'home_screen.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class WelcomeScreen extends StatelessWidget {
+  const WelcomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [Color(0xFF1E1E2C), Color(0xFF2A2A42)],
+          ),
+        ),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 30),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Hero(
+                  tag: 'logo',
+                  child: Image.asset(
+                    'assets/images/logo.png',
+                    height: 200,
+                  ),
+                ),
+                const SizedBox(height: 40),
+                _buildButton(
+                  context,
+                  label: 'Se connecter / S\'inscrire',
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (_) => const LoginScreen()),
+                    );
+                  },
+                ),
+                const SizedBox(height: 20),
+                _buildButton(
+                  context,
+                  label: 'Entrer sans compte',
+                  onTap: () {
+                    final user = FirebaseAuth.instance.currentUser;
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(builder: (_) => HomeScreen(user: user)),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildButton(BuildContext context,
+      {required String label, required VoidCallback onTap}) {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          backgroundColor: Colors.blueAccent,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        ),
+        onPressed: onTap,
+        child: Text(
+          label,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a Welcome screen for guest or login entry
- show WelcomeScreen from SplashScreen when user isn't logged in
- support nullable user in `HomeScreen`
- require authentication when launching any quiz
- update routes returning to HomeScreen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860168549a8832d93a4b81e0aceb374