### PR TITLE
Fix settings button requires auth

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -199,12 +199,14 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
               child: IconButton(
                 icon: Icon(Icons.settings, color: Colors.blueGrey, size: 40),
                 onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => SettingsScreen(user: widget.user!),
-                    ),
-                  );
+                  _requireAuth(() {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => SettingsScreen(user: widget.user!),
+                      ),
+                    );
+                  });
                 },
               ),
             ),


### PR DESCRIPTION
## Summary
- exige une authentification avant d'ouvrir l'écran des paramètres

## Testing
- `flutter test` *(échoue : `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686024acd8d0832da8444f3f7501b374