### PR TITLE
Permettre menus aux invités

### DIFF
--- a/lib/screens/classic_quiz/classic_quiz_menu_screen.dart
+++ b/lib/screens/classic_quiz/classic_quiz_menu_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '/screens/home_screen.dart';
+import '/screens/login_screen.dart';
 import '/screens/quiz_screen.dart';
 import '/screens/defis_screens/defi_quiz_screen.dart';
 import '/screens/classic_quiz/classic_histoire_quiz_screen.dart';
@@ -101,6 +102,39 @@ class _AnimatedFloatingButtonState extends State<_AnimatedFloatingButton> with S
 }
 
 class ClassicQuizMenuScreen extends StatelessWidget {
+  void _requireAuth(BuildContext context, VoidCallback onAuthenticated) {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      showDialog(
+        context: context,
+        builder: (_) => AlertDialog(
+          title: const Text('Connexion requise'),
+          content: const Text(
+            'Vous devez être connecté pour jouer. Souhaitez-vous créer un compte ?',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Plus tard'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const LoginScreen()),
+                );
+              },
+              child: const Text("S'inscrire"),
+            ),
+          ],
+        ),
+      );
+    } else {
+      onAuthenticated();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -173,50 +207,60 @@ class ClassicQuizMenuScreen extends StatelessWidget {
                 _AnimatedFloatingButton(
                   backgroundImage: 'assets/images/boiscartoon.png',
                   onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) => ClassicHistoireQuizScreen()),
-                    );
+                    _requireAuth(context, () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => ClassicHistoireQuizScreen()),
+                      );
+                    });
                   },
                   text: "Histoire",
                 ),
                 _AnimatedFloatingButton(
                   backgroundImage: 'assets/images/boiscartoon.png',
                   onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) => ClassicGeographieQuizScreen()),
-                    );
+                    _requireAuth(context, () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => ClassicGeographieQuizScreen()),
+                      );
+                    });
                   },
                   text: "Géographie",
                 ),
                 _AnimatedFloatingButton(
                   backgroundImage: 'assets/images/boiscartoon.png',
                   onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) => ClassicCultureQuizScreen()),
-                    );
+                    _requireAuth(context, () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => ClassicCultureQuizScreen()),
+                      );
+                    });
                   },
                   text: "Gastronomie, Culture & Traditions",
                 ),
                 _AnimatedFloatingButton(
                   backgroundImage: 'assets/images/boiscartoon.png',
                   onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) => ClassicFauneQuizScreen()),
-                    );
+                    _requireAuth(context, () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => ClassicFauneQuizScreen()),
+                      );
+                    });
                   },
                   text: "Faune & Flore",
                 ),
                 _AnimatedFloatingButton(
                   backgroundImage: 'assets/images/boiscartoon.png',
                   onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(builder: (context) => ClassicPersonnalitesQuizScreen()),
-                    );
+                    _requireAuth(context, () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (context) => ClassicPersonnalitesQuizScreen()),
+                      );
+                    });
                   },
                   text: "Personnalités",
                 ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -235,12 +235,10 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                         text: "Quiz Classique",
                         backgroundImage: 'assets/images/boiscartoon.png',
                         onTap: () {
-                          _requireAuth(() {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
-                            );
-                          });
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
+                          );
                         },
                       ),
                       SizedBox(height: 25),
@@ -250,12 +248,10 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                         text: "Défis Quiz",
                         backgroundImage: 'assets/images/boiscartoon.png',
                         onTap: () {
-                          _requireAuth(() {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(builder: (context) => ChallengeScreen()),
-                            );
-                          });
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => ChallengeScreen()),
+                          );
                         },
                       ),
                       SizedBox(height: 25),
@@ -298,12 +294,10 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                         text: "Classement",
                         backgroundImage: 'assets/images/boiscartoon.png',
                         onTap: () {
-                          _requireAuth(() {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(builder: (context) => ClassementScreen()),
-                            );
-                          });
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => ClassementScreen()),
+                          );
                         },
                       ),
                     ],


### PR DESCRIPTION
## Summary
- autoriser l'accès aux menus `Quiz Classique`, `Défis Quiz` et `Classement` même sans connexion
- bloquer le lancement des quiz si l'utilisateur n'est pas authentifié
- empêcher l'accès au défi si l'utilisateur invité n'est pas connecté

## Testing
- `flutter test` *(échoue : flutter non installé)*

------
https://chatgpt.com/codex/tasks/task_e_686026e4cfc8832d85fcb06d8673083c