### PR TITLE
Gestion du profil lors de l'auth Apple

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -297,9 +297,14 @@ class _LoginScreenState extends State<LoginScreen> {
                     onTap: () async {
                       User? user = await _authService.signInWithApple();
                       if (user != null) {
+                        bool hasProfile = await ProfileService().hasProfile(user.uid);
                         Navigator.pushReplacement(
                           context,
-                          MaterialPageRoute(builder: (context) => HomeScreen(user: user)),
+                          MaterialPageRoute(
+                            builder: (context) => hasProfile
+                                ? HomeScreen(user: user)
+                                : ProfileScreen(user: user),
+                          ),
                         );
                       }
                     },


### PR DESCRIPTION
## Résumé
- création d'un `ProfileService` interne dans `AuthService`
- création automatique du profil après connexion avec Apple
- redirection conditionnelle selon l'existence du profil après login Apple

## Tests
- `flutter test test/auth_service_test.dart` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6860365cb8b4832da970ebdb2edcb79f