### PR TITLE
Gestion échec connexion Apple

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -306,6 +306,10 @@ class _LoginScreenState extends State<LoginScreen> {
                                 : ProfileScreen(user: user),
                           ),
                         );
+                      } else {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('Échec de la connexion')),
+                        );
                       }
                     },
                     icon: "assets/icons/apple.png",


### PR DESCRIPTION
## Summary
- afficher un SnackBar si la connexion Apple échoue

## Testing
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68603a8a643c832d9ecb6a90325d436d