### PR TITLE
Ajout de tests Apple

### DIFF
--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -69,4 +69,13 @@ void main() {
     final doc = await firestore.collection('users').doc('u1').get();
     expect(doc.data()?['online'], false);
   });
+
+  test('signInWithApple renvoie null si la plateforme n\'est pas iOS/macOS', () async {
+    final auth = MockFirebaseAuth();
+    final service = AuthService(auth: auth);
+
+    final user = await service.signInWithApple();
+
+    expect(user, isNull);
+  });
 }

--- a/test/login_screen_test.dart
+++ b/test/login_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:corsicaquiz/screens/login_screen.dart';
 import 'package:corsicaquiz/services/auth_service.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:flutter/foundation.dart';
 
 class MockAuthService extends Mock implements AuthService {}
 
@@ -23,6 +24,23 @@ void main() {
     await tester.pumpWidget(MaterialApp(home: LoginScreen(authService: mockAuth)));
 
     await tester.tap(find.text('Se connecter avec Google'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.text('Échec de la connexion'), findsOneWidget);
+  });
+
+  testWidgets('Affiche un SnackBar si la connexion Apple échoue', (tester) async {
+    final mockAuth = MockAuthService();
+    when(() => mockAuth.signInWithApple()).thenAnswer((_) async => null);
+
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    await tester.pumpWidget(MaterialApp(home: LoginScreen(authService: mockAuth)));
+
+    await tester.tap(find.text('Se connecter avec Apple'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 


### PR DESCRIPTION
## Summary
- test de l'échec de connexion Apple sur l'écran de login
- vérification que `signInWithApple` retourne null hors iOS/macOS

## Testing
- `flutter test` *(échoue : commande introuvable)*
- `dart test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68603a8fb2f0832da019de7b0e7688cf