### PR TITLE
Update final result messages

### DIFF
--- a/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
@@ -29,6 +29,11 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
       debugPrint("Erreur de lecture du son bell : \$e");
     }
 
+    final loggedIn = FirebaseAuth.instance.currentUser != null;
+    final msg = loggedIn
+        ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
+        : 'Tu as gagné \$_score glands !';
+
     await showDialog(
       context: context,
       barrierDismissible: false,
@@ -58,7 +63,7 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
                 ),
                 SizedBox(height: 10),
                 Text(
-                  'Tu as gagné $_score glands !\nIls ont été ajoutés à ton profil.',
+                  msg,
                   textAlign: TextAlign.center,
                   style: TextStyle(fontSize: 16),
                 ),

--- a/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
@@ -29,6 +29,11 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
       debugPrint("Erreur de lecture du son bell : \$e");
     }
 
+    final loggedIn = FirebaseAuth.instance.currentUser != null;
+    final msg = loggedIn
+        ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
+        : 'Tu as gagné \$_score glands !';
+
     await showDialog(
       context: context,
       barrierDismissible: false,
@@ -58,7 +63,7 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
                 ),
                 SizedBox(height: 10),
                 Text(
-                  'Tu as gagné $_score glands !\nIls ont été ajoutés à ton profil.',
+                  msg,
                   textAlign: TextAlign.center,
                   style: TextStyle(fontSize: 16),
                 ),

--- a/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
@@ -28,6 +28,11 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
       debugPrint("Erreur de lecture du son bell : \$e");
     }
 
+    final loggedIn = FirebaseAuth.instance.currentUser != null;
+    final msg = loggedIn
+        ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
+        : 'Tu as gagné \$_score glands !';
+
     await showDialog(
       context: context,
       barrierDismissible: false,
@@ -57,7 +62,7 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
                 ),
                 SizedBox(height: 10),
                 Text(
-                  'Tu as gagné $_score glands️ !\nIls ont été ajoutés à ton profil.',
+                  msg,
                   textAlign: TextAlign.center,
                   style: TextStyle(fontSize: 16),
                 ),

--- a/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
@@ -28,6 +28,11 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
       debugPrint("Erreur de lecture du son bell : \$e");
     }
 
+    final loggedIn = FirebaseAuth.instance.currentUser != null;
+    final msg = loggedIn
+        ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
+        : 'Tu as gagné \$_score glands !';
+
     await showDialog(
       context: context,
       barrierDismissible: false,
@@ -57,7 +62,7 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
                 ),
                 SizedBox(height: 10),
                 Text(
-                  'Tu as gagné $_score glands !\nIls ont été ajoutés à ton profil.',
+                  msg,
                   textAlign: TextAlign.center,
                   style: TextStyle(fontSize: 16),
                 ),


### PR DESCRIPTION
## Summary
- adapt final result dialogs in classic quiz screens
- show different message when user not logged in

## Testing
- `flutter format lib/screens/classic_quiz/classic_histoire_quiz_screen.dart lib/screens/classic_quiz/classic_culture_quiz_screen.dart lib/screens/classic_quiz/classic_faune_quiz_screen.dart lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628e4f8430832da5750f3abecec304