### PR TITLE
Ajout message incitatif pour invités

### DIFF
--- a/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
@@ -12,6 +12,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import '/services/ad_service.dart';
 import '../../services/background_music_service.dart';
 import '../../services/question_history_service.dart';
+import '../login_screen.dart';
 
 
 class ClassicCultureQuizScreen extends StatefulWidget {
@@ -32,7 +33,7 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
     final loggedIn = FirebaseAuth.instance.currentUser != null;
     final msg = loggedIn
         ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
-        : 'Tu as gagné \$_score glands !';
+        : 'Tu as gagné \$_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
 
     await showDialog(
       context: context,
@@ -68,22 +69,60 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
                   style: TextStyle(fontSize: 16),
                 ),
                 SizedBox(height: 20),
-                ElevatedButton(
-                  onPressed: () {
-                    AdService.showInterstitial();
-                    Navigator.pop(context);
-                    Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
-                    );
-                  },
-                  child: Text('Retour au menu'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.orange.shade700,
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                if (loggedIn)
+                  ElevatedButton(
+                    onPressed: () {
+                      AdService.showInterstitial();
+                      Navigator.pop(context);
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
+                      );
+                    },
+                    child: Text('Retour au menu'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.orange.shade700,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    ),
+                  )
+                else
+                  Column(
+                    children: [
+                      ElevatedButton(
+                        onPressed: () {
+                          AdService.showInterstitial();
+                          Navigator.pop(context);
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
+                          );
+                        },
+                        child: Text('Continuer en invité'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.orange.shade700,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      ),
+                      SizedBox(height: 10),
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.pop(context);
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => const LoginScreen()),
+                          );
+                        },
+                        child: Text("S'inscrire"),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.green.shade700,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      )
+                    ],
                   ),
-                ),
               ],
             ),
           ),

--- a/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
@@ -12,6 +12,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import '/services/ad_service.dart';
 import '../../services/background_music_service.dart';
 import '../../services/question_history_service.dart';
+import '../login_screen.dart';
 
 
 class ClassicFauneQuizScreen extends StatefulWidget {
@@ -32,7 +33,7 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
     final loggedIn = FirebaseAuth.instance.currentUser != null;
     final msg = loggedIn
         ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
-        : 'Tu as gagné \$_score glands !';
+        : 'Tu as gagné \$_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
 
     await showDialog(
       context: context,
@@ -68,22 +69,60 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
                   style: TextStyle(fontSize: 16),
                 ),
                 SizedBox(height: 20),
-                ElevatedButton(
-                  onPressed: () {
-                    AdService.showInterstitial();
-                    Navigator.pop(context);
-                    Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
-                    );
-                  },
-                  child: Text('Retour au menu'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.orange.shade700,
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                if (loggedIn)
+                  ElevatedButton(
+                    onPressed: () {
+                      AdService.showInterstitial();
+                      Navigator.pop(context);
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
+                      );
+                    },
+                    child: Text('Retour au menu'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.orange.shade700,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    ),
+                  )
+                else
+                  Column(
+                    children: [
+                      ElevatedButton(
+                        onPressed: () {
+                          AdService.showInterstitial();
+                          Navigator.pop(context);
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
+                          );
+                        },
+                        child: Text('Continuer en invité'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.orange.shade700,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      ),
+                      SizedBox(height: 10),
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.pop(context);
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => const LoginScreen()),
+                          );
+                        },
+                        child: Text("S'inscrire"),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.green.shade700,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      )
+                    ],
                   ),
-                ),
               ],
             ),
           ),

--- a/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
@@ -11,6 +11,7 @@ import 'classic_quiz_menu_screen.dart';
 import '/services/ad_service.dart';
 import '../../services/background_music_service.dart';
 import '../../services/question_history_service.dart';
+import '../login_screen.dart';
 
 class ClassicGeographieQuizScreen extends StatefulWidget {
   ClassicGeographieQuizScreen({super.key});
@@ -172,6 +173,11 @@ class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScree
     } catch (e) {
       debugPrint("Erreur de lecture du son bell : $e");
     }
+    final loggedIn = FirebaseAuth.instance.currentUser != null;
+    final scoreMsg = loggedIn
+        ? 'Score : \$_score / \${_cities.length}'
+        : 'Score : \$_score / \${_cities.length}\nTon score ne sera pas enregistré car tu joues en invité.';
+
     showDialog(
       context: context,
       barrierDismissible: false,
@@ -187,19 +193,51 @@ class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScree
               SizedBox(height: 10),
               Text('Quiz terminé !', style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
               SizedBox(height: 10),
-              Text('Score : $_score / ${_cities.length}', textAlign: TextAlign.center),
+              Text(scoreMsg, textAlign: TextAlign.center),
               SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: () {
-                  AdService.showInterstitial();
-                  Navigator.pop(context);
-                  Navigator.pushReplacement(
-                    context,
-                    MaterialPageRoute(builder: (c) => ClassicQuizMenuScreen()),
-                  );
-                },
-                child: Text('Retour au menu'),
-              )
+              if (loggedIn)
+                ElevatedButton(
+                  onPressed: () {
+                    AdService.showInterstitial();
+                    Navigator.pop(context);
+                    Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(builder: (c) => ClassicQuizMenuScreen()),
+                    );
+                  },
+                  child: Text('Retour au menu'),
+                )
+              else
+                Column(
+                  children: [
+                    ElevatedButton(
+                      onPressed: () {
+                        AdService.showInterstitial();
+                        Navigator.pop(context);
+                        Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(builder: (c) => ClassicQuizMenuScreen()),
+                        );
+                      },
+                      child: Text('Continuer en invité'),
+                    ),
+                    SizedBox(height: 10),
+                    ElevatedButton(
+                      onPressed: () {
+                        Navigator.pop(context);
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(builder: (context) => const LoginScreen()),
+                        );
+                      },
+                      child: Text("S'inscrire"),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.green.shade700,
+                        foregroundColor: Colors.white,
+                      ),
+                    )
+                  ],
+                )
             ],
           ),
         ),

--- a/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
@@ -12,6 +12,7 @@ import '/screens/classic_quiz/classic_quiz_menu_screen.dart';
 import '/services/ad_service.dart';
 import '../../services/background_music_service.dart';
 import '../../services/question_history_service.dart';
+import '../login_screen.dart';
 
 class ClassicHistoireQuizScreen extends StatefulWidget {
   @override
@@ -31,7 +32,7 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
     final loggedIn = FirebaseAuth.instance.currentUser != null;
     final msg = loggedIn
         ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
-        : 'Tu as gagné \$_score glands !';
+        : 'Tu as gagné \$_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
 
     await showDialog(
       context: context,
@@ -67,22 +68,60 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
                   style: TextStyle(fontSize: 16),
                 ),
                 SizedBox(height: 20),
-                ElevatedButton(
-                  onPressed: () {
-                    AdService.showInterstitial();
-                    Navigator.pop(context);
-                    Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
-                    );
-                  },
-                  child: Text('Retour au menu'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.orange.shade700,
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                if (loggedIn)
+                  ElevatedButton(
+                    onPressed: () {
+                      AdService.showInterstitial();
+                      Navigator.pop(context);
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
+                      );
+                    },
+                    child: Text('Retour au menu'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.orange.shade700,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    ),
+                  )
+                else
+                  Column(
+                    children: [
+                      ElevatedButton(
+                        onPressed: () {
+                          AdService.showInterstitial();
+                          Navigator.pop(context);
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
+                          );
+                        },
+                        child: Text('Continuer en invité'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.orange.shade700,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      ),
+                      SizedBox(height: 10),
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.pop(context);
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => const LoginScreen()),
+                          );
+                        },
+                        child: Text("S'inscrire"),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.green.shade700,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      )
+                    ],
                   ),
-                ),
               ],
             ),
           ),

--- a/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
@@ -11,6 +11,7 @@ import '/screens/classic_quiz/classic_quiz_menu_screen.dart';
 import '/services/ad_service.dart';
 import '../../services/background_music_service.dart';
 import '../../services/question_history_service.dart';
+import '../login_screen.dart';
 
 class ClassicPersonnalitesQuizScreen extends StatefulWidget {
   @override
@@ -31,7 +32,7 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
     final loggedIn = FirebaseAuth.instance.currentUser != null;
     final msg = loggedIn
         ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
-        : 'Tu as gagné \$_score glands !';
+        : 'Tu as gagné \$_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
 
     await showDialog(
       context: context,
@@ -67,22 +68,60 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
                   style: TextStyle(fontSize: 16),
                 ),
                 SizedBox(height: 20),
-                ElevatedButton(
-                  onPressed: () {
-                    AdService.showInterstitial();
-                    Navigator.pop(context);
-                    Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
-                    );
-                  },
-                  child: Text('Retour au menu'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.orange.shade700,
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                if (loggedIn)
+                  ElevatedButton(
+                    onPressed: () {
+                      AdService.showInterstitial();
+                      Navigator.pop(context);
+                      Navigator.pushReplacement(
+                        context,
+                        MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
+                      );
+                    },
+                    child: Text('Retour au menu'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.orange.shade700,
+                      foregroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    ),
+                  )
+                else
+                  Column(
+                    children: [
+                      ElevatedButton(
+                        onPressed: () {
+                          AdService.showInterstitial();
+                          Navigator.pop(context);
+                          Navigator.pushReplacement(
+                            context,
+                            MaterialPageRoute(builder: (context) => ClassicQuizMenuScreen()),
+                          );
+                        },
+                        child: Text('Continuer en invité'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.orange.shade700,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      ),
+                      SizedBox(height: 10),
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.pop(context);
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (context) => const LoginScreen()),
+                          );
+                        },
+                        child: Text("S'inscrire"),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.green.shade700,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
+                      )
+                    ],
                   ),
-                ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- invite the user to sign up when finishing a classic quiz as a guest
- offer choice to continue as guest or register

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686290f2c040832dbd68c2bc37b88291