### PR TITLE
Correction de l'interpolation du score

### DIFF
--- a/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_culture_quiz_screen.dart
@@ -32,8 +32,8 @@ class _ClassicCultureQuizScreenState extends State<ClassicCultureQuizScreen> wit
 
     final loggedIn = FirebaseAuth.instance.currentUser != null;
     final msg = loggedIn
-        ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
-        : 'Tu as gagné \$_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
+        ? 'Tu as gagné $_score glands !\nIls ont été ajoutés à ton profil.'
+        : 'Tu as gagné $_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
 
     await showDialog(
       context: context,

--- a/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_faune_quiz_screen.dart
@@ -32,8 +32,8 @@ class _ClassicFauneQuizScreenState extends State<ClassicFauneQuizScreen> with Ti
 
     final loggedIn = FirebaseAuth.instance.currentUser != null;
     final msg = loggedIn
-        ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
-        : 'Tu as gagné \$_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
+        ? 'Tu as gagné $_score glands !\nIls ont été ajoutés à ton profil.'
+        : 'Tu as gagné $_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
 
     await showDialog(
       context: context,

--- a/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_geographie_quiz_screen.dart
@@ -175,8 +175,8 @@ class _ClassicGeographieQuizScreenState extends State<ClassicGeographieQuizScree
     }
     final loggedIn = FirebaseAuth.instance.currentUser != null;
     final scoreMsg = loggedIn
-        ? 'Score : \$_score / \${_cities.length}'
-        : 'Score : \$_score / \${_cities.length}\nTon score ne sera pas enregistré car tu joues en invité.';
+        ? 'Score : $_score / \${_cities.length}'
+        : 'Score : $_score / \${_cities.length}\nTon score ne sera pas enregistré car tu joues en invité.';
 
     showDialog(
       context: context,

--- a/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_histoire_quiz_screen.dart
@@ -31,8 +31,8 @@ class _ClassicHistoireQuizScreenState extends State<ClassicHistoireQuizScreen> w
 
     final loggedIn = FirebaseAuth.instance.currentUser != null;
     final msg = loggedIn
-        ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
-        : 'Tu as gagné \$_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
+        ? 'Tu as gagné $_score glands !\nIls ont été ajoutés à ton profil.'
+        : 'Tu as gagné $_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
 
     await showDialog(
       context: context,

--- a/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
+++ b/lib/screens/classic_quiz/classic_personnalites_quiz_screen.dart
@@ -31,8 +31,8 @@ class _ClassicPersonnalitesQuizScreenState extends State<ClassicPersonnalitesQui
 
     final loggedIn = FirebaseAuth.instance.currentUser != null;
     final msg = loggedIn
-        ? 'Tu as gagné \$_score glands !\nIls ont été ajoutés à ton profil.'
-        : 'Tu as gagné \$_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
+        ? 'Tu as gagné $_score glands !\nIls ont été ajoutés à ton profil.'
+        : 'Tu as gagné $_score glands !\nTon score ne sera pas enregistré car tu joues en invité.';
 
     await showDialog(
       context: context,


### PR DESCRIPTION
## Résumé
- correction des chaînes finales dans les écrans de quiz pour interpoler correctement `_score`

## Tests
- `flutter test` *(échoue : commande introuvable)*
- `dart analyze` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6863a154ad00832d9f27e66d3a4b3dcd