### PR TITLE
Ajout logs d'erreur interstitiel

### DIFF
--- a/lib/services/ad_service.dart
+++ b/lib/services/ad_service.dart
@@ -35,6 +35,7 @@ class AdService {
           _interstitialReady = true;
         },
         onAdFailedToLoad: (error) {
+          print('Erreur chargement interstitiel: $error');
           _interstitialReady = false;
         },
       ),
@@ -51,6 +52,7 @@ class AdService {
           loadInterstitial();
         },
         onAdFailedToShowFullScreenContent: (ad, error) {
+          print('Erreur chargement interstitiel: $error');
           // En cas d'erreur d'affichage, on détruit l'instance
           // et on tente de recharger pour la prochaine fois
           ad.dispose();


### PR DESCRIPTION
## Summary
- ajoute des impressions d'erreur lors du chargement et de l'affichage des interstitiels

## Testing
- `flutter test` *(échoue : commande introuvable)*
- `dart test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6863a55b2eac832d9e99593b43344a29