### PR TITLE
Intégration d'App Tracking Transparency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ samples, guidance on mobile development, and a full API reference.
 ## Nouveauté
 
 * Possibilité de demander une **Revanche** depuis l'écran de résultat d'un duel.
+
+## Confidentialité iOS
+
+L'application utilise le package `app_tracking_transparency` pour demander
+l'autorisation de suivi publicitaire au démarrage.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -51,9 +51,11 @@
 	</dict>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Utilisation de Face ID pour se connecter avec Apple.</string>
-	<key>NSLocalNetworkUsageDescription</key>
-	<string>Cette app a besoin d&apos;accéder au réseau local pour le débogage et certaines fonctionnalités.</string>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
+        <key>NSLocalNetworkUsageDescription</key>
+        <string>Cette app a besoin d&apos;accéder au réseau local pour le débogage et certaines fonctionnalités.</string>
+        <key>NSUserTrackingUsageDescription</key>
+        <string>Cette application utilise votre identifiant publicitaire pour personnaliser les publicités.</string>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'services/notification_service.dart';
 import 'services/ad_service.dart';
 import 'services/background_music_service.dart';
 import 'theme_notifier.dart';
+import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -18,6 +19,7 @@ void main() async {
   );
   await NotificationService.init();
   await ThemeNotifier.loadTheme();
+  await AppTrackingTransparency.requestTrackingAuthorization();
   await AdService.init();
   BackgroundMusicService.instance.play();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   package_info_plus: ^8.3.0
   shared_preferences: ^2.2.2
   google_mobile_ads: ^5.0.0
+  app_tracking_transparency: ^2.0.4
 
 
 dev_dependencies:


### PR DESCRIPTION
## Résumé
- ajoute la dépendance `app_tracking_transparency`
- demande l'autorisation de suivi avant l'initialisation des pubs
- ajoute la clef `NSUserTrackingUsageDescription` dans le `Info.plist`
- documente brièvement cette étape dans le README

## Tests
- `flutter analyze` *(échec : commande introuvable)*
- `flutter test` *(échec : commande introuvable)*


------
https://chatgpt.com/codex/tasks/task_e_6863e048bf6c832d90cca9fab9aca9f3