### PR TITLE
Ajout databaseURL dans la configuration Firebase

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,32 @@
-{"flutter":{"platforms":{"android":{"default":{"projectId":"quizcorsica","appId":"1:109788230031:android:2d5beda26c1bdcfa989bfa","fileOutput":"android/app/google-services.json"}},"ios":{"default":{"projectId":"quizcorsica","appId":"1:109788230031:ios:1889b0a679821a9b989bfa","uploadDebugSymbols":false,"fileOutput":"ios/Runner/GoogleService-Info.plist"}},"dart":{"lib/firebase_options.dart":{"projectId":"quizcorsica","configurations":{"android":"1:109788230031:android:2d5beda26c1bdcfa989bfa","ios":"1:109788230031:ios:1889b0a679821a9b989bfa"}}}}}}
+{
+  "flutter": {
+    "platforms": {
+      "android": {
+        "default": {
+          "projectId": "quizcorsica",
+          "appId": "1:109788230031:android:2d5beda26c1bdcfa989bfa",
+          "fileOutput": "android/app/google-services.json",
+          "databaseURL": "https://quizcorsica-default-rtdb.europe-west1.firebasedatabase.app"
+        }
+      },
+      "ios": {
+        "default": {
+          "projectId": "quizcorsica",
+          "appId": "1:109788230031:ios:1889b0a679821a9b989bfa",
+          "uploadDebugSymbols": false,
+          "fileOutput": "ios/Runner/GoogleService-Info.plist",
+          "databaseURL": "https://quizcorsica-default-rtdb.europe-west1.firebasedatabase.app"
+        }
+      },
+      "dart": {
+        "lib/firebase_options.dart": {
+          "projectId": "quizcorsica",
+          "configurations": {
+            "android": "1:109788230031:android:2d5beda26c1bdcfa989bfa",
+            "ios": "1:109788230031:ios:1889b0a679821a9b989bfa"
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -55,6 +55,7 @@ class DefaultFirebaseOptions {
     messagingSenderId: '109788230031',
     projectId: 'quizcorsica',
     storageBucket: 'quizcorsica.firebasestorage.app',
+    databaseURL: 'https://quizcorsica-default-rtdb.europe-west1.firebasedatabase.app',
   );
 
   static const FirebaseOptions ios = FirebaseOptions(
@@ -63,6 +64,7 @@ class DefaultFirebaseOptions {
     messagingSenderId: '109788230031',
     projectId: 'quizcorsica',
     storageBucket: 'quizcorsica.firebasestorage.app',
+    databaseURL: 'https://quizcorsica-default-rtdb.europe-west1.firebasedatabase.app',
     iosClientId: '109788230031-p59g4m2378mcirc3jr9kf4ipsddlm5fi.apps.googleusercontent.com',
     iosBundleId: 'com.msj2025.corsicaquiz',
   );


### PR DESCRIPTION
## Résumé
- ajoute la propriété `databaseURL` aux configurations Android et iOS dans `firebase_options.dart`
- met à jour `firebase.json` pour inclure ce champ lors de la génération FlutterFire

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_68659c6f0fb4832d89f233a32e7f5828