### PR TITLE
Fix duplicate Firebase initialization

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,9 +14,11 @@ import 'package:app_tracking_transparency/app_tracking_transparency.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  }
   await NotificationService.init();
   await ThemeNotifier.loadTheme();
   await AppTrackingTransparency.requestTrackingAuthorization();


### PR DESCRIPTION
## Summary
- avoid duplicate Firebase initialization by checking existing apps first

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661dc1059c832da8494018edd00274