### PR TITLE
Ajout des indexes Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ samples, guidance on mobile development, and a full API reference.
 
 L'application utilise le package `app_tracking_transparency` pour demander
 l'autorisation de suivi publicitaire au démarrage.
+
+## Indexes Firestore
+
+Les index composites nécessaires à l'application sont définis dans `firestore.indexes.json` à la racine du projet. Pour les déployer, exécutez :
+
+```bash
+firebase deploy --only firestore:indexes
+```

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,23 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "duels",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "participants", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "duels",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "to", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}


### PR DESCRIPTION
## Résumé
- ajout d'un fichier `firestore.indexes.json` décrivant deux indexes composites pour la collection `duels`
- documentation rapide du déploiement de ces indexes dans le README

## Tests
- `flutter test` *(échoue : commande introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_686959975714832d8b670aaa19ddc833