### PR TITLE
Ajout de la gestion d’erreurs dans les StreamBuilder

### DIFF
--- a/lib/screens/duel_screens/accepted_duels_screen.dart
+++ b/lib/screens/duel_screens/accepted_duels_screen.dart
@@ -22,7 +22,7 @@ class AcceptedDuelsScreen extends StatelessWidget {
           if (snapshot.hasError) {
             return const Center(child: Text("Erreur de chargement"));
           }
-          if (snapshot.connectionState == ConnectionState.waiting) {
+          if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());
           }
 

--- a/lib/screens/duel_screens/duel_dashboard_screen.dart
+++ b/lib/screens/duel_screens/duel_dashboard_screen.dart
@@ -115,7 +115,12 @@ class _AcceptedDuelsWidgetState extends State<AcceptedDuelsWidget> {
     return StreamBuilder<QuerySnapshot>(
       stream: query,
       builder: (context, snapshot) {
-        if (!snapshot.hasData) return const Center(child: CircularProgressIndicator());
+        if (snapshot.hasError) {
+          return const Center(child: Text('Erreur de chargement'));
+        }
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
 
         final docs = snapshot.data!.docs;
         final duels = docs.where((doc) {
@@ -270,7 +275,12 @@ class _PendingDuelsWidgetState extends State<PendingDuelsWidget> {
     return StreamBuilder<QuerySnapshot>(
       stream: query.snapshots(),
       builder: (context, snapshot) {
-        if (!snapshot.hasData) return const Center(child: CircularProgressIndicator());
+        if (snapshot.hasError) {
+          return const Center(child: Text('Erreur de chargement'));
+        }
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
 
         final requests = snapshot.data!.docs;
         final uid = currentUser?.uid;
@@ -430,7 +440,12 @@ class _HistoryDuelsWidgetState extends State<HistoryDuelsWidget> {
     return StreamBuilder<QuerySnapshot>(
       stream: query.snapshots(),
       builder: (context, snapshot) {
-        if (!snapshot.hasData) return const Center(child: CircularProgressIndicator());
+        if (snapshot.hasError) {
+          return const Center(child: Text('Erreur de chargement'));
+        }
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
 
         final allDocs = snapshot.data!.docs;
         final docs = allDocs.where((doc) {

--- a/lib/screens/duel_screens/duel_menu_screen.dart
+++ b/lib/screens/duel_screens/duel_menu_screen.dart
@@ -142,6 +142,12 @@ class _DuelMenuScreenState extends State<DuelMenuScreen> with SingleTickerProvid
                 StreamBuilder<int>(
                   stream: DuelService().totalUnreadDuels(FirebaseAuth.instance.currentUser!.uid),
                   builder: (context, snapshot) {
+                    if (snapshot.hasError) {
+                      return const Center(child: Text('Erreur de chargement'));
+                    }
+                    if (!snapshot.hasData) {
+                      return const Center(child: CircularProgressIndicator());
+                    }
                     final count = snapshot.data ?? 0;
                     return _CustomButton(
                       onPressed: () {

--- a/lib/screens/duel_screens/duel_overview_screen.dart
+++ b/lib/screens/duel_screens/duel_overview_screen.dart
@@ -182,6 +182,9 @@ class _DuelOverviewScreenState extends State<DuelOverviewScreen> with SingleTick
             .snapshots(),
       ),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return const Center(child: Text('Erreur de chargement'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }
@@ -286,6 +289,9 @@ class _DuelOverviewScreenState extends State<DuelOverviewScreen> with SingleTick
           .where('status', isEqualTo: 'pending')
           .snapshots(),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return const Center(child: Text('Erreur de chargement'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }
@@ -346,6 +352,9 @@ class _DuelOverviewScreenState extends State<DuelOverviewScreen> with SingleTick
           .where('status', isEqualTo: 'accepted')
           .snapshots(),
       builder: (context, snapshot) {
+        if (snapshot.hasError) {
+          return const Center(child: Text('Erreur de chargement'));
+        }
         if (!snapshot.hasData) {
           return const Center(child: CircularProgressIndicator());
         }

--- a/lib/screens/duel_screens/duel_user_list_screen.dart
+++ b/lib/screens/duel_screens/duel_user_list_screen.dart
@@ -274,6 +274,9 @@ class _DuelUserListScreenState extends State<DuelUserListScreen> {
                   child: StreamBuilder<QuerySnapshot>(
                     stream: FirebaseFirestore.instance.collection('users').snapshots(),
                     builder: (context, snapshot) {
+                      if (snapshot.hasError) {
+                        return const Center(child: Text('Erreur de chargement'));
+                      }
                       if (!snapshot.hasData) {
                         return const Center(child: CircularProgressIndicator());
                       }


### PR DESCRIPTION
## Résumé
- ajout du contrôle `snapshot.hasError` sur tous les `StreamBuilder` des écrans de duel
- affichage d'un message `Erreur de chargement` lorsqu'un flux remonte une erreur

## Tests
- *Aucun test exécuté : environnement Flutter/Dart absent*


------
https://chatgpt.com/codex/tasks/task_e_686959939b38832d8e7f9ee9356e762d